### PR TITLE
i18n の導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'net-pop'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
+gem 'rails-i18n', '~> 6.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.1.6)
       actionpack (= 6.1.6)
       activesupport (= 6.1.6)
@@ -304,6 +307,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.6)
+  rails-i18n (~> 6.0)
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/views/shared/_bottom_navbar.html.erb
+++ b/app/views/shared/_bottom_navbar.html.erb
@@ -3,19 +3,19 @@
     <div class="flex justify-center items-center">
       <button class="group inline-block text-center mx-3">
         <i class="custom-icon fa-solid fa-house group-hover:text-mitsuboshi-blue"></i>
-        <p class="icon-text group-hover:text-mitsuboshi-blue">ホーム</p>
+        <p class="icon-text group-hover:text-mitsuboshi-blue"><%= t 'defaults.home' %></p>
       </button>
       <button class="group inline-block text-center mx-3">
         <i class="custom-icon fa-solid fa-magnifying-glass group-hover:text-mitsuboshi-blue"></i>
-        <p class="icon-text group-hover:text-mitsuboshi-blue">検索</p>
+        <p class="icon-text group-hover:text-mitsuboshi-blue"><%= t 'defaults.search' %></p>
       </button>
       <button class="group inline-block text-center mx-1.5">
         <i class="custom-icon fa-solid fa-user group-hover:text-mitsuboshi-blue"></i>
-        <p class="icon-text group-hover:text-mitsuboshi-blue">マイページ</p>
+        <p class="icon-text group-hover:text-mitsuboshi-blue"><%= t 'defaults.mypage' %></p>
       </button>
       <button class="group inline-block text-center mx-3">
         <i class="custom-icon fa-solid fa-plus group-hover:text-mitsuboshi-blue"></i>
-        <p class="icon-text group-hover:text-mitsuboshi-blue">投稿</p>
+        <p class="icon-text group-hover:text-mitsuboshi-blue"><%= t 'defaults.post' %></p>
       </button>
     </div>
   <div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,8 @@
 <footer class="bg-base-color px-2 py-1.5">
   <div class="flex justify-center items-center">
-    <a href="#" class="inline-block align-middle mx-2 py-0.5">利用規約</a>
-    <a href="#" class="inline-block align-middle mx-2 py-0.5">プライバシーポリシー</a>
-    <a href="#" class="inline-block align-middle mx-2 py-0.5">お問い合わせ</a>
+    <a href="#" class="inline-block align-middle mx-2 py-0.5"><%= t 'defaults.terms' %></a>
+    <a href="#" class="inline-block align-middle mx-2 py-0.5"><%= t 'defaults.privacy' %></a>
+    <a href="#" class="inline-block align-middle mx-2 py-0.5"><%= t 'defaults.contact' %>
+</a>
   </div>
 </footer>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,6 @@
   <div class="flex justify-center items-center">
     <a href="#" class="inline-block align-middle mx-2 py-0.5"><%= t 'defaults.terms' %></a>
     <a href="#" class="inline-block align-middle mx-2 py-0.5"><%= t 'defaults.privacy' %></a>
-    <a href="#" class="inline-block align-middle mx-2 py-0.5"><%= t 'defaults.contact' %>
-</a>
+    <a href="#" class="inline-block align-middle mx-2 py-0.5"><%= t 'defaults.contact' %></a>
   </div>
 </footer>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,8 @@ module MitsuboshiPowderRooms
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -10,6 +10,7 @@ ja:
         email: 'メールアドレス'
         password: 'パスワード'
         password_confirmation: 'パスワード確認'
+        avator: 'アバター'
       spot:
         name: 'スポット名'
         address: '住所'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,19 @@
+ja:
+  activerecord:
+    models:
+      user: 'ユーザー'
+      spot: 'スポット'
+      feedback : '評価'
+    attributes:
+      user:
+        name: 'アカウント名'
+        email: 'メールアドレス'
+        password: 'パスワード'
+        password_confirmation: 'パスワード確認'
+      spot:
+        name: 'スポット名'
+        address: '住所'
+      feedback:
+        number_of_stars: '総合点'
+        feedback_comment: '評価コメント'
+

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,21 @@
+ja:
+  defaults:
+    login: 'ログイン'
+    register: '登録'
+    logout: 'ログアウト'
+    home: 'ホーム'
+    mypage: 'マイページ'
+    search: '検索'
+    post: '投稿'
+    terms: '利用規約'
+    privacy: 'プライバシーポリシー'
+    contact: 'お問い合わせ'
+  users:
+    new:
+      title: 'ユーザー登録'
+      to_login_page: 'ログインページへ'
+  user_sessions:
+    new:
+      title: 'ログイン'
+      to_register_page: '登録ページへ'
+      password_forget: 'パスワードをお忘れの方はこちら'


### PR DESCRIPTION
## 概要
以下を実装しました。

b3c2b12　rails-i18n をインストール
db7f0a8　`config/application` に i18n の設定を追加
77f9b1df　view 側の `ja.yml` を追加、各ページに反映
63fc9d2　activerecord 側の `ja.yml` (user、spot、feedback テーブル) を追加

## 確認方法
以下をご確認ください。

① `shared/_footer`、`shared/_bottom_navbar` のコードが i18n の形式になっていること。

（例）`shared/_footer` の場合

<img width="762" alt="ae3c1b0092a472f534bbec77867783d5" src="https://user-images.githubusercontent.com/93573830/177959830-be547100-4c4e-4881-8cd3-630755cedf99.png">

② `bundle exec foreman start` でサーバーを起動、
　 フッター、ナビゲーションバーが日本語表示になっていること。

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした

## コメント
