### PR TITLE
Flash メッセージの設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :success, :info, :warning, :danger
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,14 +4,15 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to root_path
+      redirect_back_or_to root_path, success: t('.success')
     else
+      flash.now[:danger] = t('.fail')
       render :new
     end
   end
 
   def destroy
     logout
-    redirect_to root_path
+    redirect_to root_path, success: t('.success')
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path
+      redirect_to login_path, success: t('.success')
     else
+      flash.now[:danger] = t('.fail')
       render :new
     end
   end

--- a/app/javascript/stylesheets/tailwind.css
+++ b/app/javascript/stylesheets/tailwind.css
@@ -5,7 +5,6 @@
 @tailwind components;
 @tailwind utilities;
 
-
 @layer base {
   html {
     font-family: Josefin Sans, sans-serif;
@@ -19,12 +18,26 @@
   .nomal-btn {
     @apply bg-mitsuboshi-blue hover:bg-baby-blue;
   }
-
   .custom-icon {
     @apply w-5 h-5 text-white py-1 px-3 hover:text-mitsuboshi-blue;
   },
   .icon-text {
     @apply font-yusei text-xs text-white;
+  }
+  .alert {
+    @apply p-4 mb-4;
+  }
+  .alert-success {
+    @apply text-green-700 bg-green-100 rounded-lg;
+  }
+  .alert-info {
+    @apply text-blue-700 bg-blue-100 rounded-lg;
+  }
+  .alert-warning {
+    @apply text-yellow-700 bg-yellow-100 rounded-lg; 
+  }
+  .alert-danger {
+    @apply text-red-700 bg-red-100 rounded-lg;
   }
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
+    <%= render 'shared/flash_message' %>
     <div class="container mx-auto px-5 flex justify-center align-center">
       <%= yield %>
     </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,3 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert alert-<%= message_type %>"><%= message %></div>
+<% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -15,8 +15,16 @@ ja:
     new:
       title: 'ユーザー登録'
       to_login_page: 'ログインページへ'
+    create:
+      success: 'ユーザー登録が完了しました'
+      fail: 'ユーザー登録に失敗しました'
   user_sessions:
     new:
       title: 'ログイン'
       to_register_page: 'ユーザー登録の方は'
       password_forget: 'パスワードをお忘れの方は'
+    create:
+      success: 'ログインしました'
+      fail: 'ログインに失敗しました'
+    destroy:
+      success: 'ログアウトしました'


### PR DESCRIPTION
## 概要
Flash メッセージを実装しました。

7044887　`application_controller` に flash message の定義を追加
bf972d4　ログイン、ログアウト時の flash message を追加
7323610　ユーザー作成時の flash message を追加
e5094f3　flash message の部分テンプレートを作成
f3fa3fb　Tailwind にアラートごとのスタイルを設定
aa2a7bc　部分テンプレートをページ上部に表示するように設定
32506fa　flash message の翻訳定義を追加

## 確認方法
`bundle exec foreman start` でサーバーを起動。
以下のフラッシュメッセージが表示されることを確認してください。

#### ユーザー登録まわり
- ユーザー登録成功時 …「ユーザー登録が成功しました」

[![Image from Gyazo](https://i.gyazo.com/b208d2b3c4237f7da710f97591fb7a67.png)](https://gyazo.com/b208d2b3c4237f7da710f97591fb7a67)

- ユーザー登録失敗時 …「ユーザー登録に失敗しました」

[![Image from Gyazo](https://i.gyazo.com/527c3bd26862f7f55dfdabee2788a91a.png)](https://gyazo.com/527c3bd26862f7f55dfdabee2788a91a)

#### ログインまわり
- ログイン成功時 …「ログインが成功しました」

[![Image from Gyazo](https://i.gyazo.com/11706ff0db45ea1a39ac423368483def.png)](https://gyazo.com/11706ff0db45ea1a39ac423368483def)

- ログイン失敗時 ... 「ログインに失敗しました」

[![Image from Gyazo](https://i.gyazo.com/c04f8fca42e205a7b198cce7225a8e7a.png)](https://gyazo.com/c04f8fca42e205a7b198cce7225a8e7a)

- ログアウト成功時 …「ログアウトが成功しました」

[![Image from Gyazo](https://i.gyazo.com/bf62f0aaa83f28110cb47d2e12722a1b.png)](https://gyazo.com/bf62f0aaa83f28110cb47d2e12722a1b)

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした
