### PR TITLE
エラーメッセージの設定

### DIFF
--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id="error_messages" class="alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,7 @@
 <div class="w-full max-w-sm my-24">
   <h1 class="font-bold mb-6"><%= t('.title') %></h1>
     <%= form_with model: @user, local: true do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
       <div class="mb-4">
         <%= f.label :name, class: 'block mb-1 pr-4' %>
         <%= f.text_field :name, class: 'w-full rounded py-1 px-2' %>


### PR DESCRIPTION
## 概要
エラーメッセージを表示するため、以下を実装しました。

db6f104　エラーメッセージ用の部分テンプレートを作成する
1354891　ユーザー登録画面にエラーメッセージを表示

## 確認方法
`bundle exec foreman start` でサーバーを起動。
以下のメッセージが表示されることを確認してください。

#### ユーザー登録画面（`users/new`）

[![Image from Gyazo](https://i.gyazo.com/6058143632c80102078e06720205a4d1.png)](https://gyazo.com/6058143632c80102078e06720205a4d1)
 
## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした
