### PR TITLE
Target_people テーブルの作成、既存テーブルの修正

### DIFF
--- a/app/models/equipment_detail.rb
+++ b/app/models/equipment_detail.rb
@@ -1,6 +1,7 @@
 class EquipmentDetail < ApplicationRecord
   has_many :equipments, dependent: :destroy
   has_many :spots, through: :equipments
+  belongs_to :target_person
 
   validates :content, presence: true
 end

--- a/app/models/target_person.rb
+++ b/app/models/target_person.rb
@@ -1,5 +1,5 @@
 class TargetPerson < ApplicationRecord
   has_one :equipment_detail, dependent: :destroy
 
-  validates :people, uniqueness: true, presence: true
+  validates :target, uniqueness: true, presence: true
 end

--- a/app/models/target_person.rb
+++ b/app/models/target_person.rb
@@ -1,0 +1,2 @@
+class TargetPerson < ApplicationRecord
+end

--- a/app/models/target_person.rb
+++ b/app/models/target_person.rb
@@ -1,2 +1,5 @@
 class TargetPerson < ApplicationRecord
+  has_one :equipment_detail, dependent: :destroy
+
+  validates :people, uniqueness: true, presence: true
 end

--- a/db/migrate/20220719080411_create_target_people.rb
+++ b/db/migrate/20220719080411_create_target_people.rb
@@ -1,7 +1,7 @@
 class CreateTargetPeople < ActiveRecord::Migration[6.1]
   def change
     create_table :target_people do |t|
-      t.string :people
+      t.string :people, null: false
 
       t.timestamps
     end

--- a/db/migrate/20220719080411_create_target_people.rb
+++ b/db/migrate/20220719080411_create_target_people.rb
@@ -1,0 +1,9 @@
+class CreateTargetPeople < ActiveRecord::Migration[6.1]
+  def change
+    create_table :target_people do |t|
+      t.string :people
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220719085301_add_target_person_id_to_equipment_details.rb
+++ b/db/migrate/20220719085301_add_target_person_id_to_equipment_details.rb
@@ -1,0 +1,5 @@
+class AddTargetPersonIdToEquipmentDetails < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :equipment_details, :target_person, foreign_key: true
+  end
+end

--- a/db/migrate/20220720012658_rename_people_column_to_target_people.rb
+++ b/db/migrate/20220720012658_rename_people_column_to_target_people.rb
@@ -1,0 +1,5 @@
+class RenamePeopleColumnToTargetPeople < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :target_people, :people, :target
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_19_080411) do
+ActiveRecord::Schema.define(version: 2022_07_19_085301) do
 
   create_table "equipment", force: :cascade do |t|
     t.integer "spot_id", null: false
@@ -26,6 +26,8 @@ ActiveRecord::Schema.define(version: 2022_07_19_080411) do
     t.string "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "target_person_id"
+    t.index ["target_person_id"], name: "index_equipment_details_on_target_person_id"
   end
 
   create_table "spots", force: :cascade do |t|
@@ -59,5 +61,6 @@ ActiveRecord::Schema.define(version: 2022_07_19_080411) do
 
   add_foreign_key "equipment", "equipment_details"
   add_foreign_key "equipment", "spots"
+  add_foreign_key "equipment_details", "target_people"
   add_foreign_key "spots", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_19_064243) do
+ActiveRecord::Schema.define(version: 2022_07_19_080411) do
 
   create_table "equipment", force: :cascade do |t|
     t.integer "spot_id", null: false
@@ -37,6 +37,12 @@ ActiveRecord::Schema.define(version: 2022_07_19_064243) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_spots_on_user_id"
+  end
+
+  create_table "target_people", force: :cascade do |t|
+    t.string "people", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_19_085301) do
+ActiveRecord::Schema.define(version: 2022_07_20_012658) do
 
   create_table "equipment", force: :cascade do |t|
     t.integer "spot_id", null: false
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2022_07_19_085301) do
   end
 
   create_table "target_people", force: :cascade do |t|
-    t.string "people", null: false
+    t.string "target", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/target_people.rb
+++ b/spec/factories/target_people.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :target_person do
-    people { "MyString" }
+    people { 'MyString' }
   end
 end

--- a/spec/factories/target_people.rb
+++ b/spec/factories/target_people.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :target_person do
-    people { 'MyString' }
+    target { 'MyString' }
   end
 end

--- a/spec/factories/target_people.rb
+++ b/spec/factories/target_people.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :target_person do
+    people { "MyString" }
+  end
+end

--- a/spec/models/target_person_spec.rb
+++ b/spec/models/target_person_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TargetPerson, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
#### Target_people の作成
f818db5　`bundle exec rails g model Target_people people:string` を実行
52ce5e0　people カラムに `null: false` を追加
3c1ac56f　`bundle exec rails db:migrate` を実行、target_people を作成

#### 既存テーブルの修正
791d5f8　equipment_detail に target_person の外部キーを追加
6c5d69f　equipment_detail と target_person モデルにそれぞれの関係性を追加
0b189bb　target_people のカラムを target に修正
31e3b86　バリデーションのカラムを target に修正
7ffde1b　factorybot のカラムを target に修正

## 確認方法
File changed から、コードに問題がないか確認してください。
コンソール（`bundle exec rails c`）から 、TargetPerson.all などを実行、エラーが出ないことを確認してください。

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした

## コメント
TargetPerson、EquipmentDetail モデルのデータを、次回 seed にて作成予定。