### PR TITLE
TargetPerson 、EquipmentDetail モデルに初期データを追加 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'rails-i18n', '~> 6.0'
 gem 'dotenv-rails'
 gem 'sorcery'
 gem 'pry-byebug'
+gem 'seed-fu'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    seed-fu (2.3.9)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
     selenium-webdriver (4.3.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -382,6 +385,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sass-rails (>= 6)
+  seed-fu
   solargraph
   sorcery
   spring

--- a/db/fixtures/01_target_people.rb
+++ b/db/fixtures/01_target_people.rb
@@ -1,14 +1,5 @@
-targetperson.seed_once do |s|
-  s.id = 1
-  s.target = 'きれい好きな人'
-end
-
-TargetPerson.seed do |s|
-  s.id = 2
-  s.target = 'おしゃれが好きな女性'
-end
-
-TargetPerson.seed do |s|
-  s.id = 3
-  s.target = '小さなお子さん連れの女性'
-end
+TargetPerson.seed_once(:id,
+  { id: 1, target: 'きれい好きな人' },
+  { id: 2, target: 'おしゃれが好きな女性' },
+  { id: 3, target: '小さなお子さん連れの女性' },
+)

--- a/db/fixtures/01_target_people.rb
+++ b/db/fixtures/01_target_people.rb
@@ -1,0 +1,14 @@
+targetperson.seed_once do |s|
+  s.id = 1
+  s.target = 'きれい好きな人'
+end
+
+TargetPerson.seed do |s|
+  s.id = 2
+  s.target = 'おしゃれが好きな女性'
+end
+
+TargetPerson.seed do |s|
+  s.id = 3
+  s.target = '小さなお子さん連れの女性'
+end

--- a/db/fixtures/02_equipment_details.rb
+++ b/db/fixtures/02_equipment_details.rb
@@ -1,0 +1,7 @@
+EquipmentDetails.seed(:id,
+  { id: 1, content: 'パウダールーム', target_person_id: 2 },
+  { id: 2, content: 'フィッティングルーム', target_person_id: 2 },
+  { id: 3, content: 'ベビーキープ', target_person_id: 3 },
+  { id: 4, content: '授乳室', target_person_id: 3 },
+  { id: 5, content: 'ベビーカー可', target_person_id: 3 },
+)

--- a/db/fixtures/02_equipment_details.rb
+++ b/db/fixtures/02_equipment_details.rb
@@ -1,4 +1,4 @@
-EquipmentDetails.seed(:id,
+EquipmentDetail.seed(:id,
   { id: 1, content: 'パウダールーム', target_person_id: 2 },
   { id: 2, content: 'フィッティングルーム', target_person_id: 2 },
   { id: 3, content: 'ベビーキープ', target_person_id: 3 },

--- a/db/migrate/20220720080818_add_index_to_target_people_target.rb
+++ b/db/migrate/20220720080818_add_index_to_target_people_target.rb
@@ -1,0 +1,5 @@
+class AddIndexToTargetPeopleTarget < ActiveRecord::Migration[6.1]
+  def change
+    add_index :target_people, :target, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_20_012658) do
+ActiveRecord::Schema.define(version: 2022_07_20_080818) do
 
   create_table "equipment", force: :cascade do |t|
     t.integer "spot_id", null: false
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2022_07_20_012658) do
     t.string "target", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["target"], name: "index_target_people_on_target", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,4 +91,7 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+    config.before(:suite) do
+      SeedFu.seed
+    end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,7 +91,7 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
-    config.before(:suite) do
-      SeedFu.seed
-    end
+  config.before(:suite) do
+    SeedFu.seed
+  end
 end


### PR DESCRIPTION
## 概要
TargetPerson 、EquipmentDetail モデルに初期データを追加しました。

852f751　gem seed-fu をインストール
d04b3f0　TargetPerson のデータファイルを作成
eaa910a　EquipmentDetail のデータファイルを作成
7abc40a　RSpec 実行時、Seed Fu が実行されるように処理を追加

## 確認方法
以下の手順で、初期データが作成されることを確認してください。
① `bundle install` を実行
② `bundle exec rails db:seed_fu` を実行
③ コンソール（`bundle exec rails c`）からデータを確認
#### `TargetPerson.all` を実行
[![Image from Gyazo](https://i.gyazo.com/0d523ff31c8259558a2a4eb68dd7c375.png)](https://gyazo.com/0d523ff31c8259558a2a4eb68dd7c375)
#### `EquipmentDetail.all` を実行
[![Image from Gyazo](https://i.gyazo.com/52b0b80c1735caa39110deadb4f1e82e.png)](https://gyazo.com/52b0b80c1735caa39110deadb4f1e82e)

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした
