### PR TITLE
スポット情報の登録機能を作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem 'sorcery'
 gem 'pry-byebug'
 gem 'seed-fu'
 gem 'kaminari'
+gem 'gon'
+gem 'geocoder'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,8 +115,14 @@ GEM
     faraday-net_http (2.0.3)
     ffi (1.15.5)
     foreman (0.87.2)
+    geocoder (1.8.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -239,6 +245,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.5.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.5)
@@ -380,6 +388,8 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
+  geocoder
+  gon
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
+  before_action :require_login
+
+  def not_authenticated
+    flash[:warning] = t('defaults.message.require_login')
+    redirect_to login_path
+  end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,5 @@
 class HomeController < ApplicationController
+  skip_before_action :require_login, only: %i[index]
+
   def index; end
 end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -22,6 +22,6 @@ class SpotsController < ApplicationController
   private
 
   def spot_params
-    params.require(:spot).permit(:name, :address, :latitude, :longitude)
+    params.require(:spot).permit(:name, :address)
   end
 end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -6,12 +6,13 @@ class SpotsController < ApplicationController
   end
 
   def new
-    @spot = Spot.new
+    @form = SpotsForm.new(spot_params)
   end
 
   def create
-    @spot = current_user.spots.build(spot_params)
-    if @spot.save
+    @form = SpotsForm.new(spot_params)
+
+    if @form.save
       redirect_to spots_path, success: t('defaults.message.created', item: Spot.model_name.human)
     else
       flash.now['danger'] = t('defaults.message.not_created', item: Spot.model_name.human)
@@ -22,6 +23,10 @@ class SpotsController < ApplicationController
   private
 
   def spot_params
-    params.require(:spot).permit(:name, :address)
+    params.require(:spots_form).permit(
+      :name,
+      :address,
+      { equipment_detail_ids: [] }
+    ).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,4 +1,6 @@
 class SpotsController < ApplicationController
+  skip_before_action :require_login, only: %i[index]
+
   def index
     @spots = Spot.all.includes(:equipment_details).order(created_at: :desc).page(params[:page])
   end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -6,7 +6,7 @@ class SpotsController < ApplicationController
   end
 
   def new
-    @form = SpotsForm.new(spot_params)
+    @form = SpotsForm.new
   end
 
   def create

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -2,4 +2,24 @@ class SpotsController < ApplicationController
   def index
     @spots = Spot.all.includes(:equipment_details).order(created_at: :desc).page(params[:page])
   end
+
+  def new
+    @spot = Spot.new
+  end
+
+  def create
+    @spot = current_user.spots.build(spot_params)
+    if @spot.save
+      redirect_to spots_path, success: t('defaults.message.created', item: Spot.model_name.human)
+    else
+      flash.now['danger'] = t('defaults.message.not_created', item: Spot.model_name.human)
+      render :new
+    end
+  end
+
+  private
+
+  def spot_params
+    params.require(:spot).permit(:name, :address, :latitude, :longitude)
+  end
 end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -26,7 +26,7 @@ class SpotsController < ApplicationController
     params.require(:spots_form).permit(
       :name,
       :address,
-      { equipment_detail_ids: [] }
+      { equipment_detail_ids: [] },
     ).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,4 +1,6 @@
 class UserSessionsController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
   def new; end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
   def new
     @user = User.new
   end

--- a/app/forms/spots_form.rb
+++ b/app/forms/spots_form.rb
@@ -1,15 +1,40 @@
 class SpotsForm
- include ActiveModel::Model
- include ActiveModel::Attributes
+  include ActiveModel::Model
+  include ActiveModel::Attributes
 
- attribute :name, :string
- attribute :address, :string
- attribute :equipment_detail_ids
- attribute :user_id, :integer
+  attribute :name, :string
+  attribute :address, :string
+  attribute :user_id, :integer
+  attribute :equipment_detail_ids
 
- with_options presence: true do
-   validates :name, uniqueness: true
-   validates :address, uniqueness: true
-   validates :user_id
- end
+  with_options presence: true do
+    validates :name, uniqueness: true
+    validates :address, uniqueness: true
+    validates :user_id
+  end
+
+  def save
+    return false if invalid?
+
+    ActiveRecord::Base.transaction do
+      spot = Spot.new(spot_params)
+      spot.save!
+
+      equipment_detail_ids.each do |equipment_detail_id|
+        spot.equipments.create!(equipment_detail_id: equipment_detail_id)
+      end
+    end
+
+   true 
+  end
+
+  private
+
+  def spot_params
+    {
+      name: name,
+      address: address,
+      user_id: user_id
+    }
+  end
 end

--- a/app/forms/spots_form.rb
+++ b/app/forms/spots_form.rb
@@ -1,0 +1,15 @@
+class SpotsForm
+ include ActiveModel::Model
+ include ActiveModel::Attributes
+
+ attribute :name, :string
+ attribute :address, :string
+ attribute :equipment_detail_ids
+ attribute :user_id, :integer
+
+ with_options presence: true do
+   validates :name, uniqueness: true
+   validates :address, uniqueness: true
+   validates :user_id
+ end
+end

--- a/app/forms/spots_form.rb
+++ b/app/forms/spots_form.rb
@@ -22,21 +22,21 @@ class SpotsForm
 
       if equipment_detail_ids.present?
         equipment_detail_ids.each do |equipment_detail_id|
-          spot.equipments.create!(equipment_detail_id: equipment_detail_id)
+          spot.equipments.create!(equipment_detail_id:)
         end
       end
     end
 
-   true 
+    true
   end
 
   private
 
   def spot_params
     {
-      name: name,
-      address: address,
-      user_id: user_id
+      name:,
+      address:,
+      user_id:,
     }
   end
 end

--- a/app/forms/spots_form.rb
+++ b/app/forms/spots_form.rb
@@ -8,8 +8,8 @@ class SpotsForm
   attribute :equipment_detail_ids
 
   with_options presence: true do
-    validates :name, uniqueness: true
-    validates :address, uniqueness: true
+    validates :name
+    validates :address
     validates :user_id
   end
 

--- a/app/forms/spots_form.rb
+++ b/app/forms/spots_form.rb
@@ -20,8 +20,10 @@ class SpotsForm
       spot = Spot.new(spot_params)
       spot.save!
 
-      equipment_detail_ids.each do |equipment_detail_id|
-        spot.equipments.create!(equipment_detail_id: equipment_detail_id)
+      if equipment_detail_ids.present?
+        equipment_detail_ids.each do |equipment_detail_id|
+          spot.equipments.create!(equipment_detail_id: equipment_detail_id)
+        end
       end
     end
 

--- a/app/javascript/stylesheets/tailwind.css
+++ b/app/javascript/stylesheets/tailwind.css
@@ -14,10 +14,13 @@
 }
 @layer components {
   .btn {
-    @apply text-white font-bold rounded shadow py-2 px-4 w-32;
+    @apply text-center rounded shadow py-2 px-4 w-32;
   }
   .nomal-btn {
-    @apply bg-mitsuboshi-blue hover:bg-baby-blue;
+    @apply font-bold text-white bg-mitsuboshi-blue hover:bg-baby-blue;
+  }
+  .cancel-btn {
+    @apply border border-mitsuboshi-gray bg-white hover:bg-mitsuboshi-gray;
   }
   .custom-icon {
     @apply w-5 h-5 text-white py-1 px-3 hover:text-mitsuboshi-blue;

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -7,4 +7,7 @@ class Spot < ApplicationRecord
   validates :address, uniqueness: true, presence: true
   validates :latitude, presence: true
   validates :longitude, presence: true
+
+  geocoder_by :address
+  after_validation :geocode, if: :address_changed?
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -3,6 +3,9 @@ class Spot < ApplicationRecord
   has_many :equipments, dependent: :destroy
   has_many :equipment_details, dependent: :destroy, through: :equipments
 
+  validates :name, uniqueness: true
+  validates :address, uniqueness: true
+
   geocoded_by :address
   after_validation :geocode, if: :address_changed?
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -5,8 +5,6 @@ class Spot < ApplicationRecord
 
   validates :name, uniqueness: true, presence: true
   validates :address, uniqueness: true, presence: true
-  validates :latitude, presence: true
-  validates :longitude, presence: true
 
   geocoded_by :address
   after_validation :geocode, if: :address_changed?

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -8,6 +8,6 @@ class Spot < ApplicationRecord
   validates :latitude, presence: true
   validates :longitude, presence: true
 
-  geocoder_by :address
+  geocoded_by :address
   after_validation :geocode, if: :address_changed?
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -3,9 +3,6 @@ class Spot < ApplicationRecord
   has_many :equipments, dependent: :destroy
   has_many :equipment_details, dependent: :destroy, through: :equipments
 
-  validates :name, uniqueness: true, presence: true
-  validates :address, uniqueness: true, presence: true
-
   geocoded_by :address
   after_validation :geocode, if: :address_changed?
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  
+  has_many :spots
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
-  
+
   has_many :spots
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= include_gon %>
 
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>

--- a/app/views/shared/_bottom_navbar.html.erb
+++ b/app/views/shared/_bottom_navbar.html.erb
@@ -23,10 +23,12 @@
           </div>
         </li>
         <li>
-          <div class="group inline-block text-center mx-3 pt-2">
-            <i class="custom-icon fa-solid fa-plus group-hover:text-mitsuboshi-blue"></i>
-            <p class="icon-text group-hover:text-mitsuboshi-blue"><%= t 'defaults.post' %></p>
-          </div>
+          <%= link_to new_spot_path do %>
+            <div class="group inline-block text-center mx-3 pt-2">
+              <i class="custom-icon fa-solid fa-plus group-hover:text-mitsuboshi-blue"></i>
+              <p class="icon-text group-hover:text-mitsuboshi-blue"><%= t 'defaults.post' %></p>
+            </div>
+          <% end %>
         </li>
       </ul>
     </div>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -15,7 +15,11 @@
     </div>
     <div class="mb-4">
       <%= f.label :equipment_detail_ids, class: 'block mb-1 pr-4' %>
-      <%= f.collection_check_boxes :equipment_detail_ids, EquipmentDetail.all, :id, :content, include_hidden: false %>
+      <%= f.collection_check_boxes(:equipment_detail_ids, EquipmentDetail.all, :id, :content, include_hidden: false) do |b| %>
+        <div class="flex">
+          <%= b.label { b.check_box + b.text } %>
+        </div>
+      <% end %>
     </div>
     <div class="my-8 flex justify-center">
       <span class="btn cancel-btn mr-3"><%= t('defaults.cancel') %></span>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -1,0 +1,1 @@
+<p>spot#new</p>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -13,14 +13,6 @@
       </div>
       <%= f.text_field :address, class: 'w-full rounded py-1 px-2' %>
     </div>
-    <div class="mb-4">
-      <%= f.label :latitude, class: 'block mb-1 pr-4' %>
-      <%= f.text_field :latitude, size: 10, class: 'w-full rounded py-1 px-2' %>
-    </div>
-    <div class="mb-4">
-      <%= f.label :longitude, class: 'block mb-1 pr-4' %>
-      <%= f.text_field :longitude, size: 10, class: 'w-full rounded py-1 px-2' %>
-    </div>
     <div class="my-8 flex justify-center">
       <span class="btn cancel-btn mr-3"><%= t('defaults.cancel') %></span>
       <%= f.submit t('defaults.post'), class: 'btn nomal-btn' %>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="mb-4">
       <%= f.label :equipment_detail_ids, class: 'block mb-1 pr-4' %>
-      <%= f.collection_check_boxes :equipment_detail_ids, EquipmentDetail.all, :id, :content %>
+      <%= f.collection_check_boxes :equipment_detail_ids, EquipmentDetail.all, :id, :content, include_hidden: false %>
     </div>
     <div class="my-8 flex justify-center">
       <span class="btn cancel-btn mr-3"><%= t('defaults.cancel') %></span>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -1,1 +1,29 @@
-<p>spot#new</p>
+<div class="w-full max-w-sm my-24">
+  <h1 class="font-bold mb-6"><%= t('.title') %></h1>
+  <%= form_with model: @spot, local: true do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+    <div class="mb-4">
+      <%= f.label :name, class: 'block mb-1 pr-4' %>
+      <%= f.text_field :name, class: 'w-full rounded py-1 px-2' %>
+    </div>
+    <div class="mb-4">
+      <div class="flex text-center mb-2 pr-4">
+        <%= f.label :address, class: 'my-auto pt-1 mr-2' %>
+        <span class="bg-white rounded border border-gray-200 align-middle px-3 pt-2 pb-1 text-sm mr-2 hover:bg-gray-200">現在地から住所を入力</span>
+      </div>
+      <%= f.text_field :address, class: 'w-full rounded py-1 px-2' %>
+    </div>
+    <div class="mb-4">
+      <%= f.label :latitude, class: 'block mb-1 pr-4' %>
+      <%= f.text_field :latitude, size: 10, class: 'w-full rounded py-1 px-2' %>
+    </div>
+    <div class="mb-4">
+      <%= f.label :longitude, class: 'block mb-1 pr-4' %>
+      <%= f.text_field :longitude, size: 10, class: 'w-full rounded py-1 px-2' %>
+    </div>
+    <div class="my-8 flex justify-center">
+      <span class="btn cancel-btn mr-3"><%= t('defaults.cancel') %></span>
+      <%= f.submit t('defaults.post'), class: 'btn nomal-btn' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -1,6 +1,6 @@
 <div class="w-full max-w-sm my-24">
   <h1 class="font-bold mb-6"><%= t('.title') %></h1>
-  <%= form_with model: @spot, local: true do |f| %>
+  <%= form_with model: @form, url: spots_path, local: true do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <div class="mb-4">
       <%= f.label :name, class: 'block mb-1 pr-4' %>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -13,6 +13,10 @@
       </div>
       <%= f.text_field :address, class: 'w-full rounded py-1 px-2' %>
     </div>
+    <div class="mb-4">
+      <%= f.label :equipment_detail_ids, class: 'block mb-1 pr-4' %>
+      <%= f.collection_check_boxes :equipment_detail_ids, EquipmentDetail.all, :id, :content %>
+    </div>
     <div class="my-8 flex justify-center">
       <span class="btn cancel-btn mr-3"><%= t('defaults.cancel') %></span>
       <%= f.submit t('defaults.post'), class: 'btn nomal-btn' %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,29 +1,29 @@
 <div class="w-full max-w-sm my-24">
   <h1 class="font-bold mb-6"><%= t('.title') %></h1>
-    <%= form_with model: @user, local: true do |f| %>
-      <%= render 'shared/error_messages', object: f.object %>
-      <div class="mb-4">
-        <%= f.label :name, class: 'block mb-1 pr-4' %>
-        <%= f.text_field :name, class: 'w-full rounded py-1 px-2' %>
-      </div>
-      <div class="mb-4">
-        <%= f.label :email, class: 'block mb-1 pr-4' %>
-        <%= f.email_field :email, class: 'w-full rounded py-1 px-2' %>
-      </div>
-      <div class="mb-4">
-        <%= f.label :password, class: 'block mb-1 pr-4' %>
-        <%= f.password_field :password, class: 'w-full rounded py-1 px-2' %>
-      </div>
-      <div class="mb-4">
-        <%= f.label :password_confirmation, class: 'block mb-1 pr-4' %>
-        <%= f.password_field :password_confirmation, class: 'w-full rounded py-1 px-2' %>
-      </div>
-      <div class="my-8 md:text-center">
-        <%= f.submit t('defaults.register'), class: 'btn nomal-btn' %>
-      </div>
-    <% end %>
-    <div class="mt-6 text-center">
-      <%= link_to t('.to_login_page'), login_path %>
+  <%= form_with model: @user, local: true do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+    <div class="mb-4">
+      <%= f.label :name, class: 'block mb-1 pr-4' %>
+      <%= f.text_field :name, class: 'w-full rounded py-1 px-2' %>
     </div>
+    <div class="mb-4">
+      <%= f.label :email, class: 'block mb-1 pr-4' %>
+      <%= f.email_field :email, class: 'w-full rounded py-1 px-2' %>
+    </div>
+    <div class="mb-4">
+      <%= f.label :password, class: 'block mb-1 pr-4' %>
+      <%= f.password_field :password, class: 'w-full rounded py-1 px-2' %>
+    </div>
+    <div class="mb-4">
+      <%= f.label :password_confirmation, class: 'block mb-1 pr-4' %>
+      <%= f.password_field :password_confirmation, class: 'w-full rounded py-1 px-2' %>
+    </div>
+    <div class="my-8 md:text-center">
+      <%= f.submit t('defaults.register'), class: 'btn nomal-btn' %>
+    </div>
+  <% end %>
+  <div class="mt-6 text-center">
+    <%= link_to t('.to_login_page'), login_path %>
+  </div>
 </div>
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :google,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  use_https: true,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  api_key: ENV['GOOGLE_MAPS_API_KEY'],               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,7 +7,7 @@ Geocoder.configure(
   use_https: true,           # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
-  api_key: ENV['GOOGLE_MAPS_API_KEY'],               # API key for geocoding service
+  api_key: ENV['GEOCODING_API_KEY'],               # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
 
   # Exceptions that should not be rescued by default

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -18,3 +18,10 @@ ja:
         number_of_stars: '総合点'
         feedback_comment: '評価コメント'
 
+  activemodel:
+    attributes:
+      spots_form:
+        name: 'スポット名'
+        address: '住所'
+        equipment_detail_ids: 'こだわりポイント'
+

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -13,6 +13,7 @@ ja:
     contact: 'お問い合わせ'
     here: 'こちら'
     message:
+      require_login: 'ログインしてください'
       created: "%{item}を作成しました"
       not_created: "%{item}を作成できませんでした"
   users:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -11,6 +11,9 @@ ja:
     privacy: 'プライバシーポリシー'
     contact: 'お問い合わせ'
     here: 'こちら'
+    message:
+      created: "%{item}を作成しました"
+      not_created: "%{item}を作成できませんでした"
   users:
     new:
       title: 'ユーザー登録'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,7 @@ ja:
     mypage: 'マイページ'
     search: '検索'
     post: '投稿'
+    cancel: 'キャンセル'
     terms: '利用規約'
     privacy: 'プライバシーポリシー'
     contact: 'お問い合わせ'
@@ -36,4 +37,6 @@ ja:
       no_result: '登録されているスポットがありません'
       map_view: 'マップ表示'
       list_view: 'リスト表示'
+    new:
+      title: 'スポット情報'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create destroy]
-  resources :spots, only: %i[index]
+  resources :spots, only: %i[index new create]
 end

--- a/db/migrate/20220724055903_change_column_to_null.rb
+++ b/db/migrate/20220724055903_change_column_to_null.rb
@@ -1,0 +1,11 @@
+class ChangeColumnToNull < ActiveRecord::Migration[6.1]
+  def up
+    change_column_null :spots, :latitude, true
+    change_column_null :spots, :longitude, true
+  end
+
+  def down
+    change_column_null :spots, :latitude, false 
+    change_column_null :spots, :longitude, false 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_20_113537) do
+ActiveRecord::Schema.define(version: 2022_07_24_055903) do
 
   create_table "equipment", force: :cascade do |t|
     t.integer "spot_id", null: false
@@ -33,8 +33,8 @@ ActiveRecord::Schema.define(version: 2022_07_20_113537) do
   create_table "spots", force: :cascade do |t|
     t.string "name", null: false
     t.string "address", null: false
-    t.float "latitude", null: false
-    t.float "longitude", null: false
+    t.float "latitude"
+    t.float "longitude"
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
## 概要
スポットの登録機能を実装しました。
### スポット登録機能
4cbceb6　`config/route` に `spot#new`, `spot#create` を追加
49c4417　Spot コントローラーに spot#new 、spot#create の処理を追加
ccfae63　スポット登録の view を作成

55feec9　フォームオブジェクト `spots_form` を作成
d1fcc1dc　`spots_form` に save メソッドを追加
157ab56　spot の uniqueness 関連を spot モデルに移動
677abfe3　`spot#new` の `form_with` を spots_form に対応させる
737e12b2　`spot#new` に equipment_details のチェックボックスを追加
5aca54c　スポットの作成と同時に、設備情報を登録できるようにする

### 住所に応じた緯度経度の取得
c0fadc11　gon と geocoder をインストール
ce0d9eb　 Spot モデルに geocoder の設定を追加
d356f06　geocoder の設定ファイルを作成、設定を追加
4a71b62　`<%= include_gon %>` を追加

## 確認方法
① `bundle install` を実行
②`bundle exec foreman start` でサーバーを起動
③ ナビゲーションバーから `spots/new` へ移動し、スポットを登録
→ 設備詳細にチェックがあるときとないとき、両方の保存ができることを確認してください。
#### 設備詳細があるとき（リスト上）とないとき（リスト下） 
[![Image from Gyazo](https://i.gyazo.com/21f4d3c652331938498d3452e18b8a38.png)](https://gyazo.com/21f4d3c652331938498d3452e18b8a38)

④ コンソールを開く。
→ ③ で登録したスポットの緯度経度（latutude, longitude）が保存されていることを確認してください。

[![Image from Gyazo](https://i.gyazo.com/43aaa762bab60f9cfe4f4cb5e69057fa.png)](https://gyazo.com/43aaa762bab60f9cfe4f4cb5e69057fa)

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした

## コメント
チェックボックスのレイアウト（`collection_check_boxes` を使うかどうか）については、
後日、検討する。