### PR TITLE
tailwind.config.js に safelist を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,3 @@
 @import '@fortawesome/fontawesome-free/scss/fontawesome';
 @import '@fortawesome/fontawesome-free/scss/solid';
 @import '@fortawesome/fontawesome-free/scss/regular';
-@import '@fortawesome/fontawesome-free/scss/brands';
-@import '@fortawesome/fontawesome-free/scss/v4-shims';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,7 @@ module.exports = {
     'alert-success',
     'alert-info',
     'alert-warning',
-    'alert-danger'
+    'alert-danger',
   ],
   theme: {
     extend: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,16 @@ module.exports = {
     './app/**/*.{vue,js,ts}',
   ],
   darkMode: false, // or 'media' or 'class'
+  safelist: [
+    'powder-pink',
+    'baby-pink',
+    'fitting-pink',
+    'mitsuboshi-gray',
+    'alert-success',
+    'alert-info',
+    'alert-warning',
+    'alert-danger'
+  ],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## 概要
Heroku デプロイ時、Tailwind の一部スタイルが反映されない問題解消のため、
以下を追加しました。

f7fd317　`tailwind.config.js` に `safelist` を追加

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした
