### PR TITLE
エラー検証③_Tailwind の一部スタイルが反映されない

### DIFF
--- a/app/helpers/flash_helper.rb
+++ b/app/helpers/flash_helper.rb
@@ -1,11 +1,12 @@
 module FlashHelper
+  FLASH = {
+    'success' => 'text-green-700 bg-green-100 rounded-lg p-4 mb-4',
+    'info' => 'text-blue-700 bg-blue-100 rounded-lg p-4 mb-4',
+    'warning' => 'text-yellow-700 bg-yellow-100 rounded-lg p-4 mb-4',
+    'danger' => 'text-red-700 bg-red-100 rounded-lg p-4 mb-4',
+  }.freeze
 
-  def flash_class(message_type)
-    case message_type
-      when 'success' then 'text-green-700 bg-green-100 rounded-lg p-4 mb-4'
-      when 'info' then 'text-blue-700 bg-blue-100 rounded-lg p-4 mb-4'
-      when 'warning' then 'text-yellow-700 bg-yellow-100 rounded-lg p-4 mb-4'
-      when 'danger' then 'text-red-700 bg-red-100 rounded-lg p-4 mb-4'
-    end
+  def flash_class(type)
+    FLASH[type]
   end
 end

--- a/app/helpers/flash_helper.rb
+++ b/app/helpers/flash_helper.rb
@@ -1,0 +1,11 @@
+module FlashHelper
+
+  def flash_class(message_type)
+    case message_type
+      when 'success' then 'text-green-700 bg-green-100 rounded-lg p-4 mb-4'
+      when 'info' then 'text-blue-700 bg-blue-100 rounded-lg p-4 mb-4'
+      when 'warning' then 'text-yellow-700 bg-yellow-100 rounded-lg p-4 mb-4'
+      when 'danger' then 'text-red-700 bg-red-100 rounded-lg p-4 mb-4'
+    end
+  end
+end

--- a/app/helpers/spots_helper.rb
+++ b/app/helpers/spots_helper.rb
@@ -2,13 +2,13 @@ module SpotsHelper
   def tag_color(equipment_detail)
     case equipment_detail.target_person_id
     when 1, 2
-      'powder-pink'
+      'bg-powder-pink'
     when 3
-      'baby-blue'
+      'bg-baby-blue'
     when 4
-      'fitting-pink'
+      'bg-fitting-pink'
     else
-      'mitsuboshi-gray'
+      'bg-mitsuboshi-gray'
     end
   end
 end

--- a/app/javascript/stylesheets/tailwind.css
+++ b/app/javascript/stylesheets/tailwind.css
@@ -31,20 +31,5 @@
   .equipment-tag {
     @apply inline-block rounded-full px-2 pt-2 pb-1 text-sm font-semibold mr-2 mb-2 text-white;
   }
-  .alert {
-    @apply p-4 mb-4;
-  }
-  .alert-success {
-    @apply text-green-700 bg-green-100 rounded-lg;
-  }
-  .alert-info {
-    @apply text-blue-700 bg-blue-100 rounded-lg;
-  }
-  .alert-warning {
-    @apply text-yellow-700 bg-yellow-100 rounded-lg; 
-  }
-  .alert-danger {
-    @apply text-red-700 bg-red-100 rounded-lg;
-  }
 }
 

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,3 +1,3 @@
 <% flash.each do |message_type, message| %>
-  <div class="<%= flass_class(message_type) %>"><%= message %></div>
+  <div class="<%= flash_class(message_type) %>"><%= message %></div>
 <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,3 +1,3 @@
 <% flash.each do |message_type, message| %>
-  <div class="alert alert-<%= message_type %>"><%= message %></div>
+  <div class="<%= flass_class(message_type) %>"><%= message %></div>
 <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,3 +1,3 @@
-<% flash.each do |message_type, message| %>
-  <div class="<%= flash_class(message_type) %>"><%= message %></div>
+<% flash.each do |type, message| %>
+  <div class="<%= flash_class(type) %>"><%= message %></div>
 <% end %>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -15,7 +15,7 @@
     </div>
     <div class="flex flex-wrap text-sm ml-4 px-6 pb-2">
       <% spot.equipment_details.each do |equipment_detail| %>
-        <span class="equipment-tag bg-<%= tag_color(equipment_detail) %>">
+        <span class="equipment-tag <%= tag_color(equipment_detail) %>">
           <%= equipment_detail.content %>
         </span>
       <% end %>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,10 +11,6 @@ module.exports = {
     'bg-baby-pink',
     'bg-fitting-pink',
     'bg-mitsuboshi-gray',
-    'alert-success',
-    'alert-info',
-    'alert-warning',
-    'alert-danger',
   ],
   theme: {
     extend: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,10 +7,10 @@ module.exports = {
   ],
   darkMode: false, // or 'media' or 'class'
   safelist: [
-    'powder-pink',
-    'baby-pink',
-    'fitting-pink',
-    'mitsuboshi-gray',
+    'bg-powder-pink',
+    'bg-baby-pink',
+    'bg-fitting-pink',
+    'bg-mitsuboshi-gray',
     'alert-success',
     'alert-info',
     'alert-warning',


### PR DESCRIPTION
## 概要
Heroku へのデプロイ時、Tailwind の一部スタイルが反映されない問題を解決すべく、以下を実装しました。
#### 設備詳細タグ
78dd616　動的に変更する class を色のみから bg-XX に変更
#### フラッシュメッセージ
7ad85f5　`flash_helper` を作成、view に追加

## 確認方法
① `bundle exec foreman start` でサーバーを起動、
② ローカル環境において、**設備詳細タグ**と**フラッシュメッセージ**（info, success, warning, danger）が
表示されていることを確認してください。
## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした
