### PR TITLE
お気に入り機能の実装

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,6 +1,6 @@
 class LikesController < ApplicationController
   def create
-    spot = Spot.find(params[:id])
+    spot = Spot.find(params[:spot_id])
     current_user.like(spot)
     redirect_back fallback_location: root_path, success: t('.success')
   end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,13 +1,11 @@
 class LikesController < ApplicationController
   def create
-    spot = Spot.find(params[:spot_id])
-    current_user.like(spot)
-    redirect_back fallback_location: root_path, success: t('.success')
+    @spot = Spot.find(params[:spot_id])
+    current_user.like(@spot)
   end
 
   def destroy
-    spot = current_user.likes.find(params[:id]).spot
-    current_user.unlike(spot)
-    redirect_back fallback_location: root_path, success: t('.success')
+    @spot = current_user.likes.find(params[:id]).spot
+    current_user.unlike(@spot)
   end
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,13 @@
+class LikesController < ApplicationController
+  def create
+    spot = Spot.find(params[:id])
+    current_user.like(spot)
+    redirect_back fallback_location: root_path, success: t('.success')
+  end
+
+  def destroy
+    spot = current_user.likes.find(params[:id]).spot
+    current_user.unlike(spot)
+    redirect_back fallback_location: root_path, success: t('.success')
+  end
+end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -26,6 +26,10 @@ class SpotsController < ApplicationController
     gon.spot = @spot
   end
 
+  def likes
+    @like_spots = current_user.like_spots.include(:user).arder(created_at: :desc)
+  end
+
   private
 
   def spot_params

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,2 @@
+module LikesHelper
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ import * as ActiveStorage from '@rails/activestorage'
 import 'channels'
 import 'stylesheets/tailwind.css'
 import '@fortawesome/fontawesome-free/js/all'
+require('jquery')
 
 Rails.start()
 ActiveStorage.start()

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,2 @@
+class Like < ApplicationRecord
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,2 +1,4 @@
 class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :spot
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,4 +1,6 @@
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :spot
+
+  validates :user_id, uniqueness: { scope: :spot_id }
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -2,7 +2,7 @@ class Spot < ApplicationRecord
   belongs_to :user
   has_many :equipments, dependent: :destroy
   has_many :equipment_details, dependent: :destroy, through: :equipments
-  has_many :likes
+  has_many :likes, dependent: :destroy
 
   validates :name, uniqueness: true
   validates :address, uniqueness: true

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -2,6 +2,7 @@ class Spot < ApplicationRecord
   belongs_to :user
   has_many :equipments, dependent: :destroy
   has_many :equipment_details, dependent: :destroy, through: :equipments
+  has_many :likes
 
   validates :name, uniqueness: true
   validates :address, uniqueness: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ApplicationRecord
   def own?(object)
     id == object.user_id
   end
-  
+
   def not_own(object)
     id != object.user_id
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
     id == object.user_id
   end
 
-  def likes(spot)
+  def like(spot)
     like_spots << spot
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
 
   has_many :spots
   has_many :likes
+  has_many :like_spots, through: :likes, source: :spot
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,20 @@ class User < ApplicationRecord
     general: 0,
     admin: 1,
   }
+
+  def own?(object)
+    id == object.user_id
+  end
+
+  def likes(spot)
+    like_spots << spot
+  end
+
+  def unlike(spot)
+    like_spots.destroy(spot)
+  end
+
+  def like?(spot)
+    like_spots.include?(spot)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   has_many :spots
-  has_many :likes
+  has_many :likes, dependent: :destroy
   has_many :like_spots, through: :likes, source: :spot
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   has_many :spots
+  has_many :likes
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,10 @@ class User < ApplicationRecord
   def own?(object)
     id == object.user_id
   end
+  
+  def not_own(object)
+    id != object.user_id
+  end
 
   def like(spot)
     like_spots << spot

--- a/app/views/likes/create.js.erb
+++ b/app/views/likes/create.js.erb
@@ -1,1 +1,1 @@
-document.getElementById("js-like-button-for-spot-<%= @spot.id %>").replaceWith("<%= j(render('spots/unlike', spot: @spot) %>")
+$("#js-like-button-for-spot-<%= @spot.id %>").replaceWith("<%= j(render('spots/unlike', spot: @spot)) %>")

--- a/app/views/likes/create.js.erb
+++ b/app/views/likes/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("js-like-button-for-spot-<%= @spot.id %>").replaceWith("<%= j(render('spots/unlike', spot: @spot) %>")

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,2 +1,1 @@
-document.getElementById("js-like-button-for-spot-<%= @spot.id %>").replaceWith("<%= j(render('spots/like', spot: @spot) %>")
-
+$("#js-like-button-for-spot-<%= @spot.id %>").replaceWith("<%= j(render('spots/like', spot: @spot)) %>")

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,0 +1,2 @@
+document.getElementById("js-like-button-for-spot-<%= @spot.id %>").replaceWith("<%= j(render('spots/like', spot: @spot) %>")
+

--- a/app/views/spots/_like.html.erb
+++ b/app/views/spots/_like.html.erb
@@ -1,4 +1,7 @@
-<%= link_to likes_path(spot_id: spot.id), method: :post do %>
+<%= link_to likes_path(spot_id: spot.id), 
+            id: "js-like-button-for-spot-#{spot.id}",
+            method: :post,
+            remote: true do %>
   <span class="absolute top-0 right-0 p-3 rounded rounded-full hover:bg-gray-200">
     <i class="far fa-heart fa-lg"></i>
   </span>

--- a/app/views/spots/_like.html.erb
+++ b/app/views/spots/_like.html.erb
@@ -2,7 +2,7 @@
             id: "js-like-button-for-spot-#{spot.id}",
             method: :post,
             remote: true do %>
-  <span class="absolute top-0 right-0 p-3 rounded rounded-full hover:bg-gray-200">
+  <span class="absolute top-0 right-0 p-3 rounded rounded-full text-gray-200 hover:bg-gray-200 hover:text-fitting-pink">
     <i class="far fa-heart fa-lg"></i>
   </span>
 <% end %>

--- a/app/views/spots/_like.html.erb
+++ b/app/views/spots/_like.html.erb
@@ -1,0 +1,5 @@
+<%= link_to likes_path(spot_id: spot.id), method: :post do %>
+  <span class="absolute top-0 right-0 p-3 rounded rounded-full hover:bg-gray-200">
+    <i class="far fa-heart fa-lg"></i>
+  </span>
+<% end %>

--- a/app/views/spots/_like_button.html.erb
+++ b/app/views/spots/_like_button.html.erb
@@ -1,0 +1,5 @@
+<% if current_user.like?(spot) %>
+  <%= render 'unlike', { spot: spot } %>
+<% else %>
+  <%= render 'like', { spot: spot } %>
+<% end %>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,11 +1,14 @@
 <div class="max-w-md bg-white rounded-2xl overflow-hidden shadow-lg mb-5">
   <div id="spot-id-<%= spot.id %>">
     <div class="px-6 py-4">
-      <div class="flex flex-row items-center text-xl">
+      <div class="flex relative items-center text-xl">
         <i class="fa-solid fa-location-dot text-fitting-pink pr-1.5"></i>
         <div class="font-bold tracking-wider">
           <%= link_to spot.name, spot_path(spot) %>
         </div>
+        <% if logged_in? && current_user.not_own(spot) %>
+          <%= render 'like_button', spot: spot %>
+        <% end %>
       </div>
       <div class="flex flex-row ml-5">
         <i class="fas fa-star text-mitsuboshi-yellow text-xl pr-0.5"></i>

--- a/app/views/spots/_unlike.html.erb
+++ b/app/views/spots/_unlike.html.erb
@@ -1,4 +1,4 @@
-<%= link_to like_path(current_user.likes.find_by(spot_id: spot.id),
+<%= link_to like_path(current_user.likes.find_by(spot_id: spot.id)),
     method: :delete do %>
   <span class="absolute top-0 right-0 p-3 rounded rounded-full text-fitting-pink hover:bg-gray-200">
     <i class="fa fa-heart fa-lg"></i>

--- a/app/views/spots/_unlike.html.erb
+++ b/app/views/spots/_unlike.html.erb
@@ -1,5 +1,7 @@
 <%= link_to like_path(current_user.likes.find_by(spot_id: spot.id)),
-    method: :delete do %>
+            id: "js-like-button-for-spot-#{spot.id}",
+            method: :delete,
+            remote: true do %>
   <span class="absolute top-0 right-0 p-3 rounded rounded-full text-fitting-pink hover:bg-gray-200">
     <i class="fa fa-heart fa-lg"></i>
   </span>

--- a/app/views/spots/_unlike.html.erb
+++ b/app/views/spots/_unlike.html.erb
@@ -1,0 +1,7 @@
+<%= link_to like_path(current_user.likes.find_by(spot_id: spot.id),
+    method: :delete do %>
+  <span class="absolute top-0 right-0 p-3 rounded rounded-full text-fitting-pink hover:bg-gray-200">
+    <i class="fa fa-heart fa-lg"></i>
+  </span>
+<% end %>
+

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,8 +1,11 @@
 <div class="w-full max-w-sm my-24">
   <div class="border-b-2 border-bg-mitsuboshi-gray pb-2">
-    <div class="flex flex-row items-center text-xl mb-1">
+    <div class="flex relative items-center text-xl mb-1">
       <i class="fa-solid fa-location-dot text-fitting-pink text-2xl pr-1.5"></i>
       <div class="font-bold tracking-wider"><%= @spot.name %></div>
+      <% if logged_in? && current_user.not_own(@spot) %>
+        <%= render 'like_button', spot: @spot %>
+      <% end %>
     </div>
     <div class="flex flex-row ml-5">
       <i class="fas fa-star text-mitsuboshi-yellow text-xl pr-0.5"></i>

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,7 +44,8 @@ module MitsuboshiPowderRooms
         view_specs: false,
         hepler_spec: false,
         routing_specs: false,
-        request_specs: false
+        request_specs: false,
+        assets: false
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,13 +39,13 @@ module MitsuboshiPowderRooms
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
 
     config.generators do |g|
-      g.test_framework :rspec,
-        fixtures: true,
-        view_specs: false,
-        hepler_spec: false,
-        routing_specs: false,
-        request_specs: false,
-        assets: false
+      g.test_framework :rspec
+      g.fixtures :true
+      g.view_specs :false
+      g.hepler_spec :false
+      g.routing_specs :false
+      g.request_specs :false
+      g.assets :false
     end
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -46,5 +46,10 @@ ja:
       address: '住所'
       equipment_details: '設備詳細'
       none: 'なし'
+  likes:
+    create:
+      success: 'お気に入りに追加しました'
+    destroy:
+      success: 'お気に入りから削除しました'
       
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -46,10 +46,4 @@ ja:
       address: '住所'
       equipment_details: '設備詳細'
       none: 'なし'
-  likes:
-    create:
-      success: 'お気に入りに追加しました'
-    destroy:
-      success: 'お気に入りから削除しました'
-      
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,10 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create destroy]
-  resources :spots
+  resources :spots do
+    collection do
+      get :likes
+    end
+  end
+  resources :likes, only: %i[create destroy]
 end

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -18,4 +18,11 @@ environment.plugins.prepend('Environment',
   )
 )
 
+environment.plugins.prepend('Provide',
+    new webpack.ProvidePlugin({
+        $: 'jquery/src/jquery',
+        jQuery: 'jquery/src/jquery'
+    })
+)
+
 module.exports = environment

--- a/db/migrate/20220810020325_create_likes.rb
+++ b/db/migrate/20220810020325_create_likes.rb
@@ -1,0 +1,10 @@
+class CreateLikes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :likes do |t|
+      t.integer :user_id
+      t.integer :spot_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220810020325_create_likes.rb
+++ b/db/migrate/20220810020325_create_likes.rb
@@ -1,10 +1,12 @@
 class CreateLikes < ActiveRecord::Migration[6.1]
   def change
     create_table :likes do |t|
-      t.integer :user_id
-      t.integer :spot_id
+      t.references :user, foreign_key: true
+      t.references :spot, foreign_key: true
 
       t.timestamps
     end
+
+    add_index :likes, [:user_id, :spot_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_24_055903) do
+ActiveRecord::Schema.define(version: 2022_08_10_020325) do
 
   create_table "equipment", force: :cascade do |t|
     t.integer "spot_id", null: false
@@ -28,6 +28,13 @@ ActiveRecord::Schema.define(version: 2022_07_24_055903) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "target_person_id"
     t.index ["target_person_id"], name: "index_equipment_details_on_target_person_id"
+  end
+
+  create_table "likes", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "spot_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "spots", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,6 +35,9 @@ ActiveRecord::Schema.define(version: 2022_08_10_020325) do
     t.integer "spot_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["spot_id"], name: "index_likes_on_spot_id"
+    t.index ["user_id", "spot_id"], name: "index_likes_on_user_id_and_spot_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "spots", force: :cascade do |t|
@@ -72,5 +75,7 @@ ActiveRecord::Schema.define(version: 2022_08_10_020325) do
   add_foreign_key "equipment", "equipment_details"
   add_foreign_key "equipment", "spots"
   add_foreign_key "equipment_details", "target_people"
+  add_foreign_key "likes", "spots"
+  add_foreign_key "likes", "users"
   add_foreign_key "spots", "users"
 end

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tailwindcss/postcss7-compat": "^2.2.17",
     "autoprefixer": "^9",
     "dotenv": "^16.0.1",
+    "jquery": "^3.6.0",
     "postcss": "^7",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat",
     "webpack": "^4.46.0",

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :like do
+    user_id { 1 }
+    spot_id { 1 }
+  end
+end

--- a/spec/helpers/likes_helper_spec.rb
+++ b/spec/helpers/likes_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the LikesHelper. For example:
+#
+# describe LikesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe LikesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4373,6 +4373,11 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
## 概要
ログインしているユーザーが、各スポットをお気に入りに追加できるようにしました。

866aa4a　like テーブルを作成
e6bc04b　ルーティングに `like#create`、`like#destroy` を追加
39b958e　likes_controller を作成、`create`、`destroy` を追加
08c7351　spots_controller に likes メソッドを追加
1e29804　like_button を作成、view 側にに表示
19d4cb5　jQuery をインストール、設定を追加

## 確認方法
① `bundle exec foreman start` でサーバーを起動。

② 以下の機能が実装されていることを確認してください。
**・`spots/index` のリスト表示、`spots/show` にお気に入りボタンが表示されていること
・お気に入りボタンが非同期で押せること**

[![Image from Gyazo](https://i.gyazo.com/00475cb34540af323fd621ab8afd7b41.gif)](https://gyazo.com/00475cb34540af323fd621ab8afd7b41)

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした

## コメント
プロフィールページ作成時にお気に入りに追加したスポットの一覧が見れるようにする。