### PR TITLE
スポット情報に編集、削除機能を追加

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -37,9 +37,9 @@ class SpotsController < ApplicationController
     @form = SpotForm.new(spot_params, spot: @spot)
 
     if @form.save
-      redirect_to @spot, success: 'The spot has been updated!'
+      redirect_to @spot, success: t('defaults.message.updated', item: Spot.model_name.human) 
     else
-      flash.now['danger'] = 'The spot has not been updated'
+      flash.now['danger'] = t('defaults.message.not_updated', item: Spot.model_name.human)
       render :edit
     end
   end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -29,9 +29,20 @@ class SpotsController < ApplicationController
     @feedbacks = @spot.feedbacks.includes(:user, :feedback_tags, :tags).order(created_at: :desc).limit(3)
   end
 
-  def edit; end
+  def edit
+    @form = SpotsForm.new(spot: @spot)
+  end
 
-  def update; end
+  def update
+    @form = SpotsForm.new(spot_params, spot: @spot)
+
+    if @form.save
+      redirect_to @spot, success: 'The spot has been updated!'
+    else
+      flash.now['danger'] = 'The spot has not been updated'
+      render :edit
+    end
+  end
 
   def destroy; end
 

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,6 +1,6 @@
 class SpotsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
-  before_action :find_spot, only %i[edit, update, destroy]
+  before_action :find_spot, only: %i[edit, update, destroy]
 
   def index
     @spots = Spot.all.includes(:equipment_details).order(created_at: :desc).page(params[:page])

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -30,14 +30,13 @@ class SpotsController < ApplicationController
   end
 
   def edit
-    binding.pry
     @form = SpotForm.new(spot: @spot)
   end
 
   def update
     @form = SpotForm.new(spot_params, spot: @spot)
 
-    if @form.update
+    if @form.save
       redirect_to @spot, success: 'The spot has been updated!'
     else
       flash.now['danger'] = 'The spot has not been updated'

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -8,11 +8,11 @@ class SpotsController < ApplicationController
   end
 
   def new
-    @form = SpotsForm.new
+    @form = SpotForm.new
   end
 
   def create
-    @form = SpotsForm.new(spot_params)
+    @form = SpotForm.new(spot_params)
 
     if @form.save
       redirect_to spots_path, success: t('defaults.message.created', item: Spot.model_name.human)
@@ -30,11 +30,11 @@ class SpotsController < ApplicationController
   end
 
   def edit
-    @form = SpotsForm.new(spot: @spot)
+    @form = SpotForm.new(spot: @spot)
   end
 
   def update
-    @form = SpotsForm.new(spot_params, spot: @spot)
+    @form = SpotForm.new(spot_params, spot: @spot)
 
     if @form.save
       redirect_to @spot, success: 'The spot has been updated!'
@@ -53,7 +53,7 @@ class SpotsController < ApplicationController
   private
 
   def spot_params
-    params.require(:spots_form).permit(
+    params.require(:spot_form).permit(
       :name,
       :address,
       { equipment_detail_ids: [] },

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,5 +1,6 @@
 class SpotsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
+  before_action :find_spot, only %i[edit, update, destroy]
 
   def index
     @spots = Spot.all.includes(:equipment_details).order(created_at: :desc).page(params[:page])
@@ -28,6 +29,12 @@ class SpotsController < ApplicationController
     @feedbacks = @spot.feedbacks.includes(:user, :feedback_tags, :tags).order(created_at: :desc).limit(3)
   end
 
+  def edit; end
+
+  def update; end
+
+  def destroy; end
+
   def likes
     @like_spots = current_user.like_spots.include(:user).arder(created_at: :desc)
   end
@@ -40,5 +47,9 @@ class SpotsController < ApplicationController
       :address,
       { equipment_detail_ids: [] },
     ).merge(user_id: current_user.id)
+  end
+
+  def find_spot
+    @spot = current_user.spots.find(params[:id])
   end
 end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -36,7 +36,7 @@ class SpotsController < ApplicationController
   def update
     @form = SpotForm.new(spot_params, spot: @spot)
 
-    if @form.save
+    if @form.update
       redirect_to @spot, success: 'The spot has been updated!'
     else
       flash.now['danger'] = 'The spot has not been updated'
@@ -44,7 +44,10 @@ class SpotsController < ApplicationController
     end
   end
 
-  def destroy; end
+  def destroy
+    @spot.destroy
+    redirect_to spots_path, success: t('defaults.message.deleted', item: Spot.model_name.human)
+  end
 
   def likes
     @like_spots = current_user.like_spots.include(:user).arder(created_at: :desc)

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -30,6 +30,7 @@ class SpotsController < ApplicationController
   end
 
   def edit
+    binding.pry
     @form = SpotForm.new(spot: @spot)
   end
 

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -37,7 +37,7 @@ class SpotsController < ApplicationController
     @form = SpotForm.new(spot_params, spot: @spot)
 
     if @form.save
-      redirect_to @spot, success: t('defaults.message.updated', item: Spot.model_name.human) 
+      redirect_to @spot, success: t('defaults.message.updated', item: Spot.model_name.human)
     else
       flash.now['danger'] = t('defaults.message.not_updated', item: Spot.model_name.human)
       render :edit

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -56,7 +56,7 @@ class SpotsController < ApplicationController
   private
 
   def spot_params
-    params.require(:spot_form).permit(
+    params.require(:spot).permit(
       :name,
       :address,
       { equipment_detail_ids: [] },

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,6 +1,6 @@
 class SpotsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
-  before_action :find_spot, only: %i[edit, update, destroy]
+  before_action :find_spot, only: %i[edit update destroy]
 
   def index
     @spots = Spot.all.includes(:equipment_details).order(created_at: :desc).page(params[:page])

--- a/app/forms/spot_form.rb
+++ b/app/forms/spot_form.rb
@@ -25,11 +25,10 @@ class SpotForm
     return false if invalid?
 
     ActiveRecord::Base.transaction do
-      
       spot.update!(spot_params)
-      
+
       spot.equipments.destroy_all if spot.equipments.present?
-      
+
       if equipment_detail_ids.present?
         equipment_detail_ids.each do |equipment_detail_id|
           spot.equipments.find_or_create_by!(equipment_detail_id:)
@@ -52,7 +51,7 @@ class SpotForm
     {
       name: spot.name,
       address: spot.address,
-      equipment_detail_ids: spot.equipment_detail_ids
+      equipment_detail_ids: spot.equipment_detail_ids,
     }
   end
 

--- a/app/forms/spot_form.rb
+++ b/app/forms/spot_form.rb
@@ -1,4 +1,4 @@
-class SpotsForm
+class SpotForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 

--- a/app/forms/spot_form.rb
+++ b/app/forms/spot_form.rb
@@ -25,16 +25,27 @@ class SpotForm
     return false if invalid?
 
     ActiveRecord::Base.transaction do
+      
+      spot = Spot.new(spot_params)
+      spot.save!
+
       if equipment_detail_ids.present?
         equipment_detail_ids.each do |equipment_detail_id|
           spot.equipments.create!(equipment_detail_id:)
         end
       end
-      spot.update!(name: name, addrss: address, equipment_detail_ids)
     end
 
-    resque ActiveRecord::RecordInvalid
-      false
+    true
+  end
+
+  def update
+    return false if invalid?
+
+    ActiveRecord::Base.transaction do
+      spot.update!(spot_params)
+      spot.equipment_detail_ids = equipment_detail_ids if equipment_detail_ids.present?
+    end
   end
 
   def to_model
@@ -42,6 +53,8 @@ class SpotForm
   end
 
   private
+
+  attr_reader :spot
 
   def default_attributes
     {

--- a/app/forms/spot_form.rb
+++ b/app/forms/spot_form.rb
@@ -13,7 +13,7 @@ class SpotForm
     validates :user_id
   end
 
-  delegate :presisted?, to: :spot
+  delegate :persisted?, :new_record?, to: :spot
 
   def initialize(attributes = nil, spot: Spot.new)
     @spot = spot
@@ -26,26 +26,16 @@ class SpotForm
 
     ActiveRecord::Base.transaction do
       
-      spot = Spot.new(spot_params)
-      spot.save!
+      spot.update!(spot_params)
 
       if equipment_detail_ids.present?
         equipment_detail_ids.each do |equipment_detail_id|
-          spot.equipments.create!(equipment_detail_id:)
+          spot.equipments.find_or_create_by!(equipment_detail_id:)
         end
       end
     end
-
-    true
-  end
-
-  def update
-    return false if invalid?
-
-    ActiveRecord::Base.transaction do
-      spot.update!(spot_params)
-      spot.equipment_detail_ids = equipment_detail_ids if equipment_detail_ids.present?
-    end
+  rescue ActiveRecord::RecordInvalid
+    false
   end
 
   def to_model
@@ -59,8 +49,8 @@ class SpotForm
   def default_attributes
     {
       name: spot.name,
-      address: spot.name,
-      equipment_detail_ids: spot.equipment_details
+      address: spot.address,
+      equipment_detail_ids: spot.equipment_detail_ids
     }
   end
 

--- a/app/forms/spot_form.rb
+++ b/app/forms/spot_form.rb
@@ -27,15 +27,17 @@ class SpotForm
     ActiveRecord::Base.transaction do
       
       spot.update!(spot_params)
-
+      
+      spot.equipments.destroy_all if spot.equipments.present?
+      
       if equipment_detail_ids.present?
         equipment_detail_ids.each do |equipment_detail_id|
           spot.equipments.find_or_create_by!(equipment_detail_id:)
         end
       end
     end
-  rescue ActiveRecord::RecordInvalid
-    false
+
+    true
   end
 
   def to_model

--- a/app/forms/spots_form.rb
+++ b/app/forms/spots_form.rb
@@ -13,24 +13,43 @@ class SpotsForm
     validates :user_id
   end
 
+  delegate :presisted?, to: :spot
+
+  def initialize(attributes = nil, spot: Spot.new)
+    @spot = spot
+    attributes ||= default_attributes
+    super(attributes)
+  end
+
   def save
     return false if invalid?
 
     ActiveRecord::Base.transaction do
-      spot = Spot.new(spot_params)
-      spot.save!
-
       if equipment_detail_ids.present?
         equipment_detail_ids.each do |equipment_detail_id|
           spot.equipments.create!(equipment_detail_id:)
         end
       end
+      spot.update!(name: name, addrss: address, equipment_detail_ids)
     end
 
-    true
+    resque ActiveRecord::RecordInvalid
+      false
+  end
+
+  def to_model
+    spot
   end
 
   private
+
+  def default_attributes
+    {
+      name: spot.name,
+      address: spot.name,
+      equipment_detail_ids: spot.equipment_details
+    }
+  end
 
   def spot_params
     {

--- a/app/javascript/stylesheets/tailwind.css
+++ b/app/javascript/stylesheets/tailwind.css
@@ -12,6 +12,9 @@
   .cancel-btn {
     @apply border border-mitsuboshi-gray bg-white hover:bg-mitsuboshi-gray;
   }
+  .delete-btn {
+    @apply bg-white border-none hover:text-white hover:bg-black;
+  }
   .custom-icon {
     @apply text-white py-1 px-3 hover:text-mitsuboshi-blue;
   }

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,5 +1,5 @@
 <h1 class="font-bold mb-6"><%= t('spots.new.title') %></h1>
-<%= form_with model: form, url: spots_path, local: true do |f| %>
+<%= form_with model: form, local: true do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class="mb-4">
     <%= f.label :name, class: 'block mb-1 pr-4' %>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,0 +1,28 @@
+<h1 class="font-bold mb-6"><%= t('spots.new.title') %></h1>
+<%= form_with model: form, url: spots_path, local: true do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="mb-4">
+    <%= f.label :name, class: 'block mb-1 pr-4' %>
+    <%= f.text_field :name, class: 'w-full rounded py-1 px-2' %>
+  </div>
+  <div class="mb-4">
+    <div class="flex text-center mb-2 pr-4">
+      <%= f.label :address, class: 'my-auto pt-1 mr-2' %>
+      <span class="bg-white rounded border border-gray-200 align-middle px-3 pt-2 pb-1 text-sm mr-2 hover:bg-gray-200">現在地から住所を入力</span>
+    </div>
+    <%= f.text_field :address, class: 'w-full rounded py-1 px-2' %>
+  </div>
+  <div class="mb-4">
+    <%= f.label :equipment_detail_ids, class: 'block mb-1 pr-4' %>
+    <%= f.collection_check_boxes(:equipment_detail_ids, EquipmentDetail.all, :id, :content, include_hidden: false) do |b| %>
+      <div class="flex">
+        <%= b.label { b.check_box + b.text } %>
+      </div>
+    <% end %>
+  </div>
+  <div class="my-8 flex justify-center">
+    <span class="btn cancel-btn mr-3"><%= t('defaults.cancel') %></span>
+    <%= f.submit t('defaults.post'), class: 'btn nomal-btn' %>
+  </div>
+<% end %>
+

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -6,10 +6,8 @@
     <%= f.text_field :name, class: 'w-full rounded py-1 px-2' %>
   </div>
   <div class="mb-4">
-    <div class="flex text-center mb-2 pr-4">
+    <div class="mb-2 pr-4">
       <%= f.label :address, class: 'my-auto pt-1 mr-2' %>
-      <span class="bg-white rounded border border-gray-200 align-middle px-3 pt-2 pb-1 text-sm mr-2 hover:bg-gray-200">現在地から住所を入力</span>
-    </div>
     <%= f.text_field :address, class: 'w-full rounded py-1 px-2' %>
   </div>
   <div class="mb-4">

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -18,8 +18,7 @@
       </div>
     <% end %>
   </div>
-  <div class="my-8 flex justify-center">
-    <span class="btn cancel-btn mr-3"><%= t('defaults.cancel') %></span>
+  <div class="flex justify-center">
     <%= f.submit t('defaults.post'), class: 'btn nomal-btn' %>
   </div>
 <% end %>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,25 +1,29 @@
-<h1 class="font-bold mb-6"><%= t('spots.new.title') %></h1>
 <%= form_with model: form, local: true do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
-  <div class="mb-4">
-    <%= f.label :name, class: 'block mb-1 pr-4' %>
-    <%= f.text_field :name, class: 'w-full rounded py-1 px-2' %>
+  <div class="mb-2">
+    <div class="pt-5 pb-3">
+      <%= f.label :name %>
+    </div>
+    <%= f.text_field :name, class: 'w-full rounded border border-gray-200 py-1.5 px-3' %>
   </div>
-  <div class="mb-4">
-    <div class="mb-2 pr-4">
-      <%= f.label :address, class: 'my-auto pt-1 mr-2' %>
-    <%= f.text_field :address, class: 'w-full rounded py-1 px-2' %>
+  <div class="mb-2">
+    <div class="pt-5 pb-3">
+      <%= f.label :address %>
+    </div>
+    <%= f.text_field :address, class: 'w-full rounded border border-gray-200 py-1.5 px-3' %>
   </div>
-  <div class="mb-4">
-    <%= f.label :equipment_detail_ids, class: 'block mb-1 pr-4' %>
+  <div class="mb-5">
+    <div class="pt-5 pb-3">
+      <p><%= t('activemodel.attributes.spot_form.equipment_detail_ids') %></p>
+    </div>
     <%= f.collection_check_boxes(:equipment_detail_ids, EquipmentDetail.all, :id, :content, include_hidden: false) do |b| %>
       <div class="flex">
         <%= b.label { b.check_box + b.text } %>
       </div>
     <% end %>
   </div>
-  <div class="flex justify-center">
-    <%= f.submit t('defaults.post'), class: 'btn nomal-btn' %>
+  <div class="my-8 flex justify-center">
+    <%= f.submit t('defaults.save'), class: 'btn nomal-btn' %>
   </div>
 <% end %>
 

--- a/app/views/spots/edit.html.erb
+++ b/app/views/spots/edit.html.erb
@@ -1,0 +1,3 @@
+<div class="w-full max-w-sm my-24">
+  <%= render 'form', form: @form %>
+</div>

--- a/app/views/spots/edit.html.erb
+++ b/app/views/spots/edit.html.erb
@@ -1,3 +1,4 @@
 <div class="w-full max-w-sm my-24">
+  <h1 class="font-bold mb-4"><%= t('.title') %></h1>
   <%= render 'form', form: @form %>
 </div>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -1,29 +1,3 @@
 <div class="w-full max-w-sm my-24">
-  <h1 class="font-bold mb-6"><%= t('.title') %></h1>
-  <%= form_with model: @form, url: spots_path, local: true do |f| %>
-    <%= render 'shared/error_messages', object: f.object %>
-    <div class="mb-4">
-      <%= f.label :name, class: 'block mb-1 pr-4' %>
-      <%= f.text_field :name, class: 'w-full rounded py-1 px-2' %>
-    </div>
-    <div class="mb-4">
-      <div class="flex text-center mb-2 pr-4">
-        <%= f.label :address, class: 'my-auto pt-1 mr-2' %>
-        <span class="bg-white rounded border border-gray-200 align-middle px-3 pt-2 pb-1 text-sm mr-2 hover:bg-gray-200">現在地から住所を入力</span>
-      </div>
-      <%= f.text_field :address, class: 'w-full rounded py-1 px-2' %>
-    </div>
-    <div class="mb-4">
-      <%= f.label :equipment_detail_ids, class: 'block mb-1 pr-4' %>
-      <%= f.collection_check_boxes(:equipment_detail_ids, EquipmentDetail.all, :id, :content, include_hidden: false) do |b| %>
-        <div class="flex">
-          <%= b.label { b.check_box + b.text } %>
-        </div>
-      <% end %>
-    </div>
-    <div class="my-8 flex justify-center">
-      <span class="btn cancel-btn mr-3"><%= t('defaults.cancel') %></span>
-      <%= f.submit t('defaults.post'), class: 'btn nomal-btn' %>
-    </div>
-  <% end %>
+  <%= render 'form', form: @form %>
 </div>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -1,3 +1,4 @@
 <div class="w-full max-w-sm my-24">
+  <h1 class="font-bold mb-4"><%= t('.title') %></h1>
   <%= render 'form', form: @form %>
 </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -21,12 +21,13 @@
       </div>
     </div>
   </div>
-  <% if logged_in? %>
+  <% if current_user.own?(@spot) %>
     <div class="flex justify-center pb-5">
       <button class="btn nomal-btn mr-3"><%= t('defaults.edit') %></button>
-      <button class="btn delete-btn"><%= t('defaults.destroy') %></button>
+      <%= link_to spot_path(@spot), id: "button-delete=#{@spot.id}", method: :delete do %>
+        <button class="btn delete-btn"><%= t('defaults.destroy') %></button>
+      <% end %>
     </div>
-    <div>
   <% end %>
   <%= render 'feedbacks/feedbacks', { spot: @spot, feedbacks: @feedbacks } %>
 </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -24,7 +24,7 @@
   <% if current_user.own?(@spot) %>
     <div class="flex justify-center pb-5">
       <button class="btn nomal-btn mr-3"><%= t('defaults.edit') %></button>
-      <%= link_to spot_path(@spot), id: "button-delete=#{@spot.id}", method: :delete do %>
+      <%= link_to spot_path(@spot), id: "button-delete=#{@spot.id}", method: :delete, data: { confirm: "「スポット: #{@spot.name}」を削除しますか？" } do %>
         <button class="btn delete-btn"><%= t('defaults.destroy') %></button>
       <% end %>
     </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -23,8 +23,10 @@
   </div>
   <% if logged_in? %>
     <div class="flex justify-center pb-5">
-      <button class="btn nomal-btn"><%= t('defaults.edit') %></button>
+      <button class="btn nomal-btn mr-3"><%= t('defaults.edit') %></button>
+      <button class="btn delete-btn"><%= t('defaults.destroy') %></button>
     </div>
+    <div>
   <% end %>
   <%= render 'feedbacks/feedbacks', { spot: @spot, feedbacks: @feedbacks } %>
 </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -23,7 +23,9 @@
   </div>
   <% if current_user.own?(@spot) %>
     <div class="flex justify-center pb-5">
-      <button class="btn nomal-btn mr-3"><%= t('defaults.edit') %></button>
+      <%= link_to edit_spot_path(@spot), id: "button-edit-#{@spot.id}" do %> 
+        <button class="btn nomal-btn mr-3"><%= t('defaults.edit') %></button>
+      <% end %> 
       <%= link_to spot_path(@spot), id: "button-delete=#{@spot.id}", method: :delete, data: { confirm: "「スポット: #{@spot.name}」を削除しますか？" } do %>
         <button class="btn delete-btn"><%= t('defaults.destroy') %></button>
       <% end %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -21,7 +21,7 @@
       </div>
     </div>
   </div>
-  <% if current_user.own?(@spot) %>
+  <% if logged_in? && current_user.own?(@spot) %>
     <div class="flex justify-center pb-5">
       <%= link_to edit_spot_path(@spot), id: "button-edit-#{@spot.id}" do %> 
         <button class="btn nomal-btn mr-3"><%= t('defaults.edit') %></button>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -20,7 +20,7 @@ ja:
 
   activemodel:
     attributes:
-      spots_form:
+      spot_form:
         name: 'スポット名'
         address: '住所'
         equipment_detail_ids: 'こだわりポイント'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -23,7 +23,7 @@ ja:
       spot_form:
         name: 'スポット名'
         address: '住所'
-        equipment_detail_ids: 'こだわりポイント'
+        equipment_detail_ids: '設備詳細'
       feedback_form:
         rate: '総合点'
         feedback_comment: '評価コメント'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -9,6 +9,7 @@ ja:
     post: '投稿'
     edit: '編集'
     destroy: '削除'
+    save: '保存'
     cancel: 'キャンセル'
     terms: '利用規約'
     privacy: 'プライバシーポリシー'
@@ -55,6 +56,8 @@ ja:
       none: 'なし'
       latest_feedbacks: '最近の評価'
       see_all_feedbacks: 'すべての評価を見る'
+    edit:
+      title: 'スポット編集'
   feedbacks:
     index:
       title: 'すべての評価'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,6 +8,7 @@ ja:
     search: '検索'
     post: '投稿'
     edit: '編集'
+    destroy: '削除'
     cancel: 'キャンセル'
     terms: '利用規約'
     privacy: 'プライバシーポリシー'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -21,6 +21,7 @@ ja:
       require_login: 'ログインしてください'
       created: "%{item}を作成しました"
       not_created: "%{item}を作成できませんでした"
+      deleted: "%{item}を削除しました"
   users:
     new:
       title: 'ユーザー登録'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -21,6 +21,8 @@ ja:
       require_login: 'ログインしてください'
       created: "%{item}を作成しました"
       not_created: "%{item}を作成できませんでした"
+      updated: "%{item}を編集しました"
+      not_updated: "%{item}を編集できませんでした"
       deleted: "%{item}を削除しました"
   users:
     new:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,9 @@ module.exports = {
   ],
   darkMode: false, // or 'media' or 'class'
   theme: {
+    fontFamily: {
+      'hans': ['SourceHanSans', 'sans-serif']
+    },
     extend: {
       colors: {
         'base-color': '#FFF5E9',


### PR DESCRIPTION
## 概要
スポット情報に編集、削除機能を追加しました。

cb6a1f35　spot コントローラーに `edit` `update` `destroy` を追加、`find_spot` を設定
a6f8951b　`spots#new` のフォーム部分を部分テンプレートに変更
8f07c492　`spots#show` に削除ボタンを追加
6704494　`spot#destroy` を追加、削除ボタンに `destroy` を紐付け
40ceeffc　SpotForm に `initialize` を導入、`create` できることを確認
30461857　`spots#edit` を作成、編集ボタンに `edit` を紐付け
06aa5ef10　スポット編集時、設備詳細の削除にも対応

## 確認方法
① `bundle exec foreman start` でサーバーを起動、 `spots#show` に遷移。
② 編集ボタンまたは削除ボタンをクリックし、以下の条件すべてが実装されていることを確認してください。
#### 【ログインしていないとき】
- スポット情報の詳細画面に「編集する」ボタンが表示されていないこと

<img src="https://i.gyazo.com/4d2d607d2a6040d124df280f669264a8.png" width="50%">

#### 【ログインしているとき】
- 自身の投稿したスポット情報の詳細画面にのみ、「編集する」ボタンが表示されること

<img src="https://i.gyazo.com/68839a34d573be0f816501a4cb7c335c.png" width="50%">

- スポット名、住所を変更し、編集が実行されること

<img src="https://i.gyazo.com/a832712c1dbcb4c2bcdad455b95ab186.gif" width="50%">

- 設備詳細のチェック項目を増やし、編集が実行されること

<img src="https://i.gyazo.com/15a8e03735f36eca71a835f8458646ae.gif" width="50%">

- 設備詳細のチェック項目を減らし、編集が実行されること

<img src="https://i.gyazo.com/1c0e7da605abbb84c2ce2590e6f702dc.gif" width="50%">

- 設備詳細のチェック項目をすべて外し、編集が実行されること

<img src="https://i.gyazo.com/2c9f8f55a0e57446ba03da49f90514d3.gif" width="50%">

- 削除ボタンをクリックし、該当のスポット情報が削除できること
<img src="https://i.gyazo.com/0524b133395c02233e305a0d10362ab5.gif" width="50%">

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした
