### PR TITLE
管理画面の追加②_ユーザー、スポット情報のCRUD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'seed-fu'
 gem 'kaminari'
 gem 'gon'
 gem 'geocoder'
+gem 'enum_help'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     e2mmap (0.1.0)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -385,6 +387,7 @@ DEPENDENCIES
   byebug
   capybara
   dotenv-rails
+  enum_help
   factory_bot_rails
   faker
   foreman

--- a/app/controllers/admin/spots_controller.rb
+++ b/app/controllers/admin/spots_controller.rb
@@ -1,0 +1,4 @@
+class Admin::SpotsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/admin/spots_controller.rb
+++ b/app/controllers/admin/spots_controller.rb
@@ -5,10 +5,14 @@ class Admin::SpotsController < Admin::BaseController
     @spots = Spot.all.includes(:user).order(id: :asc)
   end
 
-  def edit; end
+  def edit
+    @admin_spot_form = AdminSpotForm.new(spot: @spot)
+  end
 
   def update
-    if @spot.update(spot_params)
+    @admin_spot_form = AdminSpotForm.new(spot_params, spot: @spot)
+
+    if @admin_spot_form.save
       redirect_to admin_spot_path(@spot), success: t('defaults.message.updated', item: Spot.model_name.human)
     else
       flash.now['danger'] = t('defaults.message.not_updated', item: Spot.model_name.human)
@@ -33,7 +37,9 @@ class Admin::SpotsController < Admin::BaseController
     params.require(:spot).permit(
       :name,
       :address,
+      :latitude,
+      :longitude,
       { equipment_detail_ids: [] }
-    )
+    ).merge(user_id: @spot.user_id)
   end
 end

--- a/app/controllers/admin/spots_controller.rb
+++ b/app/controllers/admin/spots_controller.rb
@@ -1,4 +1,39 @@
-class Admin::SpotsController < ApplicationController
+class Admin::SpotsController < Admin::BaseController
+  before_action :set_spot, only: %i[edit update show destroy]
+
   def index
+    @spots = Spot.all.includes(:user).order(id: :asc)
+  end
+
+  def edit; end
+
+  def update
+    if @spot.update(spot_params)
+      redirect_to admin_spot_path(@spot), success: t('defaults.message.updated', item: Spot.model_name.human)
+    else
+      flash.now['danger'] = t('defaults.message.not_updated', item: Spot.model_name.human)
+      render :edit
+    end
+  end
+
+  def show; end
+
+  def destroy
+    @spot.destroy!
+    redirect_to admin_spots_path, success: t('defaults.message.deleted', item: Spot.model_name.human)
+  end
+
+  private
+
+  def set_spot
+    @spot = Spot.find(params[:id])
+  end
+
+  def spot_params
+    params.require(:spot).permit(
+      :name,
+      :address,
+      { equipment_detail_ids: [] }
+    )
   end
 end

--- a/app/controllers/admin/spots_controller.rb
+++ b/app/controllers/admin/spots_controller.rb
@@ -39,7 +39,7 @@ class Admin::SpotsController < Admin::BaseController
       :address,
       :latitude,
       :longitude,
-      { equipment_detail_ids: [] }
+      { equipment_detail_ids: [] },
     ).merge(user_id: @spot.user_id)
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,4 @@
+class Admin::UsersController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,4 @@
-class Admin::UsersController < ApplicationController
+class Admin::UsersController < Admin::BaseController
   def index
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,20 @@
 class Admin::UsersController < Admin::BaseController
+  before_action :set_user, only: %i[show destroy]
+
   def index
+    @users = User.all.order(created_at: :desc).page(params[:page])
+  end
+
+  def show; end
+
+  def destroy
+    @user.destroy!
+    redirect_to admin_users_path, success: t('defaults.message.delete')
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,6 +5,17 @@ class Admin::UsersController < Admin::BaseController
     @users = User.all.order(id: :asc).page(params[:page])
   end
 
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_user_path(@user), success: t('defaults.message.updated', item: User.model_name.human)
+    else
+      flash.now['danger'] = t('defaults.message.not_updated', item: User.model_name.human)
+      render :edit
+    end
+  end
+
   def show; end
 
   def destroy
@@ -16,5 +27,9 @@ class Admin::UsersController < Admin::BaseController
 
   def set_user
     @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :role)
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,7 @@ class Admin::UsersController < Admin::BaseController
   before_action :set_user, only: %i[show destroy]
 
   def index
-    @users = User.all.order(created_at: :desc).page(params[:page])
+    @users = User.all.order(id: :asc).page(params[:page])
   end
 
   def show; end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,7 @@ class Admin::UsersController < Admin::BaseController
   before_action :set_user, only: %i[edit update show destroy]
 
   def index
-    @users = User.all.order(id: :asc).page(params[:page])
+    @users = User.all.order(id: :asc)
   end
 
   def edit; end
@@ -20,7 +20,7 @@ class Admin::UsersController < Admin::BaseController
 
   def destroy
     @user.destroy!
-    redirect_to admin_users_path, success: t('defaults.message.delete')
+    redirect_to admin_users_path, success: t('defaults.message.deleted', item: User.model_name.human)
   end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UsersController < Admin::BaseController
-  before_action :set_user, only: %i[show destroy]
+  before_action :set_user, only: %i[edit update show destroy]
 
   def index
     @users = User.all.order(id: :asc).page(params[:page])

--- a/app/forms/admin_spot_form.rb
+++ b/app/forms/admin_spot_form.rb
@@ -53,6 +53,8 @@ class AdminSpotForm
     {
       name: spot.name,
       address: spot.address,
+      latitude: spot.latitude,
+      longitude: spot.longitude,
       equipment_detail_ids: spot.equipment_detail_ids,
     }
   end

--- a/app/forms/admin_spot_form.rb
+++ b/app/forms/admin_spot_form.rb
@@ -1,0 +1,69 @@
+class AdminSpotForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :name, :string
+  attribute :address, :string
+  attribute :latitude, :float
+  attribute :longitude, :float
+  attribute :user_id, :integer
+  attribute :equipment_detail_ids
+
+  with_options presence: true do
+    validates :name
+    validates :address
+    validates :user_id
+  end
+
+  delegate :persisted?, :new_record?, to: :spot
+
+  def initialize(attributes = nil, spot: Spot.new)
+    @spot = spot
+    attributes ||= default_attributes
+    super(attributes)
+  end
+
+  def save
+    return false if invalid?
+
+    ActiveRecord::Base.transaction do
+      spot.update!(spot_params)
+
+      spot.equipments.destroy_all if spot.equipments.present?
+
+      if equipment_detail_ids.present?
+        equipment_detail_ids.each do |equipment_detail_id|
+          spot.equipments.find_or_create_by!(equipment_detail_id:)
+        end
+      end
+    end
+
+    true
+  end
+
+  def to_model
+    spot
+  end
+
+  private
+
+  attr_reader :spot
+
+  def default_attributes
+    {
+      name: spot.name,
+      address: spot.address,
+      equipment_detail_ids: spot.equipment_detail_ids,
+    }
+  end
+
+  def spot_params
+    {
+      name:,
+      address:,
+      latitude:,
+      longitude:,
+      user_id:,
+    }
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,5 @@
+module AdminHelper
+  def include_latitude_and_longitude?(spot)
+    spot.latitude && spot.longitude ? '○' : '☓'
+  end
+end

--- a/app/javascript/stylesheets/admin.css
+++ b/app/javascript/stylesheets/admin.css
@@ -6,13 +6,14 @@
   .admin-btn {
     @apply text-center rounded shadow text-xs py-2 px-4 z-30;
   }
-
   .admin-nomal-btn {
     @apply bg-white border-none hover:text-white hover:bg-pink-600;
   }
-
   .admin-delete-btn {
     @apply bg-white border-none hover:text-white hover:bg-black;
+  }
+  .equipment-tag {
+    @apply inline-block rounded-full font-semibold px-2 py-1 mr-2 mb-2 text-white;
   }
 }
 

--- a/app/javascript/stylesheets/admin.css
+++ b/app/javascript/stylesheets/admin.css
@@ -1,3 +1,18 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .admin-btn {
+    @apply text-center rounded shadow text-xs py-2 px-4 z-30;
+  }
+
+  .admin-nomal-btn {
+    @apply text-white bg-pink-600; hover:bg-pink-800;
+  }
+
+  .admin-delete-btn {
+    @apply bg-white border-none hover:text-white hover:bg-black;
+  }
+}
+

--- a/app/javascript/stylesheets/admin.css
+++ b/app/javascript/stylesheets/admin.css
@@ -8,7 +8,7 @@
   }
 
   .admin-nomal-btn {
-    @apply text-white bg-pink-600; hover:bg-pink-800;
+    @apply bg-white border-none hover:text-white hover:bg-pink-600;
   }
 
   .admin-delete-btn {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
-  has_many :spots
+  has_many :spots, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_spots, through: :likes, source: :spot
   has_many :feedbacks, dependent: :destroy

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -4,11 +4,7 @@
   <div
     class="w-full mx-autp items-center flex justify-between md:flex-nowrap flex-wrap md:px-10 px-4"
   >
-    <a
-      class="text-white text-sm uppercase hidden lg:inline-block font-semibold"
-      href="./index.html"
-      >Dashboard</a
-    >
+    <%= link_to 'Dashboard', admin_root_path, class: 'text-white text-sm uppercase hidden lg:inline-block font-semibold' %>
     <ul
       class="flex-col md:flex-row list-none items-center hidden md:flex"
     >

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -11,12 +11,7 @@
     >
       <i class="fas fa-bars"></i>
     </button>
-    <a
-      class="md:block text-left md:pb-2 text-blueGray-600 mr-0 inline-block whitespace-nowrap text-sm uppercase font-bold p-4 px-0"
-      href="../../index.html"
-    >
-      Mitsuboshi Powder Rooms
-    </a>
+    <%= link_to 'Mitsuboshi Powder Rooms', admin_root_path, class: 'md:block text-left md:pb-2 text-blueGray-600 mr-0 inline-block whitespace-nowrap text-sm uppercase font-bold p-4 px-0' %>
     <ul class="md:hidden items-center flex flex-wrap list-none">
       <li class="inline-block relative">
         <a
@@ -65,12 +60,7 @@
       >
         <div class="flex flex-wrap">
           <div class="w-6/12">
-            <a
-              class="md:block text-left md:pb-2 text-blueGray-600 mr-0 inline-block whitespace-nowrap text-sm uppercase font-bold p-4 px-0"
-              href="../../index.html"
-            >
-              Mitsuboshi Powder Rooms
-            </a>
+            <%= link_to 'Mitsuboshi Powder Rooms', admin_root_path, class: 'md:block text-left md:pb-2 text-blueGray-600 mr-0 inline-block whitespace-nowrap text-sm uppercase font-bold p-4 px-0' %>
           </div>
           <div class="w-6/12 flex justify-end">
             <button
@@ -104,23 +94,17 @@
 
       <ul class="md:flex-col md:min-w-full flex flex-col list-none">
         <li class="items-center">
-          <a
-            href="./dashboard.html"
-            class="text-xs uppercase py-3 font-bold block text-pink-500 hover:text-pink-600"
-          >
+          <%= link_to admin_root_path, class: 'text-xs uppercase py-3 font-bold block text-blueGray-700 hover:text-pink-600' do %>
             <i class="fas fa-tv mr-2 text-sm opacity-75"></i>
-            Dashboard
-          </a>
+            <%= t('admin.dashboards.index.title') %>
+          <% end %>
         </li>
 
         <li class="items-center">
-          <a
-            href="./settings.html"
-            class="text-xs uppercase py-3 font-bold block text-blueGray-700 hover:text-blueGray-500"
-          >
-            <i class="fas fa-tools mr-2 text-sm text-blueGray-300"></i>
-            Settings
-          </a>
+          <%= link_to admin_users_path, class: 'text-xs uppercase py-3 font-bold block text-blueGray-700 hover:text-pink-600' do %>
+            <i class="fas fa-user-circle text-blueGray-300 mr-2 text-sm"></i>
+            <%= t('admin.users.index.title') %>
+          <% end %>
         </li>
 
         <li class="items-center">
@@ -133,93 +117,6 @@
           </a>
         </li>
 
-        <li class="items-center">
-          <a
-            href="./maps.html"
-            class="text-xs uppercase py-3 font-bold block text-blueGray-700 hover:text-blueGray-500"
-          >
-            <i
-              class="fas fa-map-marked mr-2 text-sm text-blueGray-300"
-            ></i>
-            Maps
-          </a>
-        </li>
-      </ul>
-
-      <!-- Divider -->
-      <hr class="my-4 md:min-w-full" />
-      <!-- Heading -->
-      <h6
-        class="md:min-w-full text-blueGray-500 text-xs uppercase font-bold block pt-1 pb-4 no-underline"
-      >
-        Auth Layout Pages
-      </h6>
-      <!-- Navigation -->
-
-      <ul
-        class="md:flex-col md:min-w-full flex flex-col list-none md:mb-4"
-      >
-        <li class="items-center">
-          <a
-            href="../auth/login.html"
-            class="text-blueGray-700 hover:text-blueGray-500 text-xs uppercase py-3 font-bold block"
-          >
-            <i
-              class="fas fa-fingerprint text-blueGray-300 mr-2 text-sm"
-            ></i>
-            Login
-          </a>
-        </li>
-
-        <li class="items-center">
-          <a
-            href="../auth/register.html"
-            class="text-blueGray-700 hover:text-blueGray-500 text-xs uppercase py-3 font-bold block"
-          >
-            <i
-              class="fas fa-clipboard-list text-blueGray-300 mr-2 text-sm"
-            ></i>
-            Register
-          </a>
-        </li>
-      </ul>
-
-      <!-- Divider -->
-      <hr class="my-4 md:min-w-full" />
-      <!-- Heading -->
-      <h6
-        class="md:min-w-full text-blueGray-500 text-xs uppercase font-bold block pt-1 pb-4 no-underline"
-      >
-        No Layout Pages
-      </h6>
-      <!-- Navigation -->
-
-      <ul
-        class="md:flex-col md:min-w-full flex flex-col list-none md:mb-4"
-      >
-        <li class="items-center">
-          <a
-            href="../landing.html"
-            class="text-blueGray-700 hover:text-blueGray-500 text-xs uppercase py-3 font-bold block"
-          >
-            <i
-              class="fas fa-newspaper text-blueGray-300 mr-2 text-sm"
-            ></i>
-            Landing Page
-          </a>
-        </li>
-
-        <li class="items-center">
-          <a
-            href="../profile.html"
-            class="text-blueGray-700 hover:text-blueGray-500 text-xs uppercase py-3 font-bold block"
-          >
-            <i
-              class="fas fa-user-circle text-blueGray-300 mr-2 text-sm"
-            ></i>
-            Profile Page
-          </a>
-        </li>
       </ul>
     </div>
   </div>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -108,13 +108,10 @@
         </li>
 
         <li class="items-center">
-          <a
-            href="./tables.html"
-            class="text-xs uppercase py-3 font-bold block text-blueGray-700 hover:text-blueGray-500"
-          >
+          <%= link_to admin_spots_path, class: 'text-xs uppercase py-3 font-bold block text-blueGray-700 hover:text-pink-600' do %>
             <i class="fas fa-table mr-2 text-sm text-blueGray-300"></i>
-            Tables
-          </a>
+            <%= t('admin.spots.index.title') %>
+          <% end %>
         </li>
 
       </ul>

--- a/app/views/admin/spots/_equipment_tags.html.erb
+++ b/app/views/admin/spots/_equipment_tags.html.erb
@@ -1,0 +1,20 @@
+<% spot.equipment_details.each do |equipment_detail| %>
+  <% case equipment_detail.target_person_id %>
+  <% when 1, 2 %>
+    <span class="equipment-tag bg-powder-pink">
+      <%= equipment_detail.content %>
+    </span>
+  <% when 3 %>
+    <span class="equipment-tag bg-baby-blue">
+      <%= equipment_detail.content %>
+    </span>
+  <% when 4 %>
+    <span class="equipment-tag bg-fitting-pink">
+      <%= equipment_detail.content %>
+    </span>
+  <% else %>
+    <span class="equipment-tag bg-mitsuboshi-gray">
+      <%= equipment_detail.content %>
+    </span>
+  <% end %>
+<% end %>

--- a/app/views/admin/spots/_spot.html.erb
+++ b/app/views/admin/spots/_spot.html.erb
@@ -12,6 +12,11 @@
   <td
     class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
     >
+    <%= include_latitude_and_longitude?(spot) %>
+  </td>
+  <td
+    class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+  >
     <%= spot.user.name %>
   </td>
   <td

--- a/app/views/admin/spots/_spot.html.erb
+++ b/app/views/admin/spots/_spot.html.erb
@@ -22,7 +22,7 @@
   <td
     class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
   >
-    <%= spot.created_at %>
+    <%= l spot.created_at, format: :long %>
   </td>
   <td>
     <div class="flex">

--- a/app/views/admin/spots/_spot.html.erb
+++ b/app/views/admin/spots/_spot.html.erb
@@ -1,0 +1,29 @@
+<tr>
+  <td
+    class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+  >
+    <%= spot.id %>
+  </td>
+  <td
+    class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+  >
+    <%= spot.name %>
+  </td>
+  <td
+    class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+    >
+    <%= spot.user.name %>
+  </td>
+  <td
+    class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+  >
+    <%= spot.created_at %>
+  </td>
+  <td>
+    <div class="flex">
+      <%= link_to t('defaults.show'), admin_spot_path(spot), class: 'admin-btn text-white bg-pink-600 hover:bg-pink-800 font-bold mr-2' %>
+      <%= link_to t('defaults.edit'), edit_admin_spot_path(spot), class: 'admin-btn text-white bg-pink-600 hover:bg-pink-800 font-bold mr-2' %>
+      <%= link_to t('defaults.destroy'), admin_spot_path(spot), method: :delete, data: { confirm: t('defaults.message.delete_confirm') }, class: 'admin-btn admin-delete-btn font-bold mr-2' %>
+    </div>
+  </td>
+</tr>

--- a/app/views/admin/spots/edit.html.erb
+++ b/app/views/admin/spots/edit.html.erb
@@ -57,6 +57,7 @@
               </div>
             </div>
             <div class="text-right pt-5 pr-4">
+              <%= link_to t('defaults.back'), admin_spots_path, class: 'admin-btn bg-white hover:bg-gray-600 hover:text-white font-bold mr-2' %>
               <%= f.submit t('defaults.edit'), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
             </div>
           <% end %>

--- a/app/views/admin/spots/edit.html.erb
+++ b/app/views/admin/spots/edit.html.erb
@@ -28,6 +28,18 @@
                   <%= f.text_field :address, class: 'border-0 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full ease-linear transition-all duration-150' %>
                 </div>
               </div>
+              <div class="w-full px-4 pt-3">
+                <div class="relative w-full mb-3">
+                  <%= f.label :latitude, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <%= f.number_field :latitude, step: :any, class: 'border-0 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full ease-linear transition-all duration-150' %>
+                </div>
+              </div>
+              <div class="w-full px-4 pt-3">
+                <div class="relative w-full mb-3">
+                  <%= f.label :longitude, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <%= f.number_field :longitude, step: :any, class: 'border-0 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full ease-linear transition-all duration-150' %>
+                </div>
+              </div>
             </div>
             <hr class="mt-6 border-b-1 border-blueGray-300" />
             <h6 class="text-blueGray-400 text-sm mt-3 mb-6 font-bold uppercase">

--- a/app/views/admin/spots/edit.html.erb
+++ b/app/views/admin/spots/edit.html.erb
@@ -1,0 +1,55 @@
+<div class="px-4 md:px-10 mx-auto w-full">
+  <div class="flex flex-wrap">
+    <div class="w-full lg:w-8/12 px-4">
+      <div class="relative flex flex-col min-w-0 break-words w-full mb-6 shadow-lg rounded-lg bg-blueGray-100 border-0">
+        <div class="rounded-t bg-white mb-0 px-6 py-6">
+          <div class="text-center flex justify-between">
+            <h6 class="text-blueGray-700 text-xl font-bold">
+              <%= t('.title') %>
+            </h6>
+          </div>
+        </div>
+        <div class="flex-auto px-4 lg:px-10 py-10 pt-0">
+          <%= form_with model: @admin_spot_form, url: admin_spot_path(@spot), local: true do |f| %>
+            <%= render 'shared/error_messages', object: f.object %>
+            <div class="flex flex-wrap">
+              <h6 class="text-blueGray-400 text-sm mt-3 mb-6 font-bold uppercase">
+                <%= t('defaults.about_spot') %>
+              </h6>
+              <div class="w-full px-4">
+                <div class="relative w-full mb-3">
+                  <%= f.label :name, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <%= f.text_field :name, class: 'border-0 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full ease-linear transition-all duration-150' %>
+                </div>
+              </div>
+              <div class="w-full px-4 pt-3">
+                <div class="relative w-full mb-3">
+                  <%= f.label :address, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <%= f.text_field :address, class: 'border-0 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full ease-linear transition-all duration-150' %>
+                </div>
+              </div>
+            </div>
+            <hr class="mt-6 border-b-1 border-blueGray-300" />
+            <h6 class="text-blueGray-400 text-sm mt-3 mb-6 font-bold uppercase">
+              <%= t('defaults.equipment_details') %>
+            </h6>
+            <div class="flex flex-wrap">
+              <div class="w-full px-4">
+                <div class="relative w-full mb-3">
+                  <%= f.collection_check_boxes(:equipment_detail_ids, EquipmentDetail.all, :id, :content, include_hidden: false) do |b| %>
+                    <div class="flex">
+                      <%= b.label { b.check_box + b.text } %>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+            <div class="text-right pt-5 pr-4">
+              <%= f.submit t('defaults.edit'), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/spots/index.html.erb
+++ b/app/views/admin/spots/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Spots#index</h1>
+<p>Find me in app/views/admin/spots/index.html.erb</p>

--- a/app/views/admin/spots/index.html.erb
+++ b/app/views/admin/spots/index.html.erb
@@ -1,2 +1,66 @@
-<h1>Admin::Spots#index</h1>
-<p>Find me in app/views/admin/spots/index.html.erb</p>
+<div class="px-4 md:px-10 mx-auto w-full -m-24">
+  <div class="flex flex-wrap mt-4">
+    <div class="w-full mb-12 px-4">
+      <div
+        class="relative flex flex-col min-w-0 break-words w-full mt-20 mb-20 shadow-lg rounded bg-white"
+      >
+        <div class="rounded-t mb-0 px-4 py-3 border-0">
+          <div class="flex flex-wrap items-center">
+            <div
+              class="relative w-full px-4 max-w-full flex-grow flex-1"
+            >
+              <h3 class="font-semibold text-lg text-blueGray-700">
+                <%= t('.title') %>
+              </h3>
+            </div>
+          </div>
+        </div>
+        <div class="block w-full overflow-x-auto">
+          <!-- Projects table -->
+          <table
+            class="items-center w-full bg-transparent border-collapse"
+          >
+            <thead>
+              <tr>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                >
+                 ID
+                </th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                >
+                  <%= Spot.human_attribute_name('address') %>
+                </th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                >
+                  <%= t('.latitude_and_longitude') %>
+                </th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                >
+                  <%= Spot.human_attribute_name('user_id') %>
+                </th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                >
+                  <%= t('defaults.created_at') %>
+                </th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                ></th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                ></th>
+              </tr>
+            </thead>
+            <tbody>
+              <%= render @spots %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/spots/show.html.erb
+++ b/app/views/admin/spots/show.html.erb
@@ -16,7 +16,7 @@
             <h6
               class="text-blueGray-400 text-sm mt-3 mb-6 font-bold uppercase"
             >
-              <%= t('.equipment_details') %>
+              <%= t('.about_spot') %>
             </h6>
             <div class="w-full px-4">
               <div class="relative w-full mb-3">
@@ -41,6 +41,13 @@
           >
             <%= t('.equipment_details') %>
           </h6>
+          <div class="pt-2 px-4">
+            <% if @spot.equipment_details.present? %>
+              <%= render 'equipment_tags', spot: @spot %>
+            <% else %>
+              <%= t('.none') %> 
+            <% end %>
+          </div>
           <div class="text-right pt-5 pr-4">
             <%= link_to t('defaults.edit'), edit_admin_spot_path(@spot), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
           </div>

--- a/app/views/admin/spots/show.html.erb
+++ b/app/views/admin/spots/show.html.erb
@@ -66,6 +66,7 @@
           </div>
           <div class="text-right pt-5 pr-4">
             <%= link_to t('defaults.edit'), edit_admin_spot_path(@spot), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
+              <%= link_to t('defaults.destroy'), admin_spot_path(@spot), method: :delete, data: { confirm: t('defaults.message.delete_confirm') }, class: 'admin-btn admin-delete-btn font-bold mr-2' %>
           </div>
         </div>
       </div>

--- a/app/views/admin/spots/show.html.erb
+++ b/app/views/admin/spots/show.html.erb
@@ -12,39 +12,38 @@
           </div>
         </div>
         <div class="flex-auto px-4 lg:px-10 py-10 pt-0">
-          <%= form_with model: @spot, url: admin_spot_path(@spot), local: true do |f| %>
-            <%= render 'shared/error_messages', object: f.object %>
-            <h6 class="text-blueGray-400 text-sm mt-3 mb-6 font-bold uppercase">
-              <%= t('.about_spot') %>
-            </h6>
-            <div class="flex flex-wrap">
-              <div class="w-full px-4">
-                <div class="relative w-full mb-3">
-                  <%= f.label :name, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
-                  <p><%= @spot.name %></p>
-                </div>
-              </div>
-              <div class="w-full px-4 pt-3">
-                <div class="relative w-full mb-3">
-                  <%= f.label :address, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
-                  <p><%= @spot.address %></p>
-                </div>
-              </div>
-              <div class="w-full px-4 pt-3">
-                <div class="relative w-full">
-                  <%= f.label :created_at, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
-                  <p><%= l @spot.created_at, format: :long %></p>
-                </div>
-              </div>
-            </div>
-            <hr class="mt-6 border-b-1 border-blueGray-300" />
-            <h6 class="text-blueGray-400 text-sm my-6 font-bold uppercase">
+          <div class="flex flex-wrap">
+            <h6
+              class="text-blueGray-400 text-sm mt-3 mb-6 font-bold uppercase"
+            >
               <%= t('.equipment_details') %>
             </h6>
-            <div class="text-right pt-5 pr-4">
-              <%= link_to t('defaults.edit'), edit_admin_spot_path(@spot), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
+            <div class="w-full px-4">
+              <div class="relative w-full mb-3">
+                <div class="block text-blueGray-600 text-xs font-bold mb-2">
+                  <%= Spot.human_attribute_name('name') %>
+                </div>
+                <p><%= @spot.name %></p>
+              </div>
             </div>
-          <% end %>
+            <div class="w-full px-4 pt-3">
+              <div class="relative w-full mb-3">
+                <div class="block text-blueGray-600 text-xs font-bold mb-2">
+                  <%= Spot.human_attribute_name('address') %>
+                </div>
+                <p><%= @spot.address %></p>
+              </div>
+            </div>
+          </div>
+          <hr class="mt-6 border-b-1 border-blueGray-300" />
+          <h6
+            class="text-blueGray-400 text-sm mt-3 mb-6 font-bold uppercase"
+          >
+            <%= t('.equipment_details') %>
+          </h6>
+          <div class="text-right pt-5 pr-4">
+            <%= link_to t('defaults.edit'), edit_admin_spot_path(@spot), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/admin/spots/show.html.erb
+++ b/app/views/admin/spots/show.html.erb
@@ -16,7 +16,7 @@
             <h6
               class="text-blueGray-400 text-sm mt-3 mb-6 font-bold uppercase"
             >
-              <%= t('.about_spot') %>
+              <%= t('defaults.about_spot') %>
             </h6>
             <div class="w-full px-4">
               <div class="relative w-full mb-3">
@@ -39,7 +39,7 @@
           <h6
             class="text-blueGray-400 text-sm mt-3 mb-6 font-bold uppercase"
           >
-            <%= t('.equipment_details') %>
+            <%= t('defaults.equipment_details') %>
           </h6>
           <div class="pt-2 px-4">
             <% if @spot.equipment_details.present? %>

--- a/app/views/admin/spots/show.html.erb
+++ b/app/views/admin/spots/show.html.erb
@@ -1,0 +1,52 @@
+<div class="px-4 md:px-10 mx-auto w-full">
+  <div class="flex flex-wrap">
+    <div class="w-full lg:w-8/12 px-4">
+      <div
+        class="relative flex flex-col min-w-0 break-words w-full mb-6 shadow-lg rounded-lg bg-blueGray-100 border-0"
+      >
+        <div class="rounded-t bg-white mb-0 px-6 py-6">
+          <div class="text-center flex justify-between">
+            <h6 class="text-blueGray-700 text-xl font-bold">
+              <%= t('.title') %>
+            </h6>
+          </div>
+        </div>
+        <div class="flex-auto px-4 lg:px-10 py-10 pt-0">
+          <%= form_with model: @spot, url: admin_spot_path(@spot), local: true do |f| %>
+            <%= render 'shared/error_messages', object: f.object %>
+            <h6 class="text-blueGray-400 text-sm mt-3 mb-6 font-bold uppercase">
+              <%= t('.about_spot') %>
+            </h6>
+            <div class="flex flex-wrap">
+              <div class="w-full px-4">
+                <div class="relative w-full mb-3">
+                  <%= f.label :name, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <p><%= @spot.name %></p>
+                </div>
+              </div>
+              <div class="w-full px-4 pt-3">
+                <div class="relative w-full mb-3">
+                  <%= f.label :address, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <p><%= @spot.address %></p>
+                </div>
+              </div>
+              <div class="w-full px-4 pt-3">
+                <div class="relative w-full">
+                  <%= f.label :created_at, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <p><%= l @spot.created_at, format: :long %></p>
+                </div>
+              </div>
+            </div>
+            <hr class="mt-6 border-b-1 border-blueGray-300" />
+            <h6 class="text-blueGray-400 text-sm my-6 font-bold uppercase">
+              <%= t('.equipment_details') %>
+            </h6>
+            <div class="text-right pt-5 pr-4">
+              <%= link_to t('defaults.edit'), edit_admin_spot_path(@spot), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/spots/show.html.erb
+++ b/app/views/admin/spots/show.html.erb
@@ -34,6 +34,22 @@
                 <p><%= @spot.address %></p>
               </div>
             </div>
+            <div class="w-full px-4 pt-3">
+              <div class="relative w-full mb-3">
+                <div class="block text-blueGray-600 text-xs font-bold mb-2">
+                  <%= Spot.human_attribute_name('latitude') %>
+                </div>
+                <p><%= @spot.latitude %></p>
+              </div>
+            </div>
+            <div class="w-full px-4 pt-3">
+              <div class="relative w-full mb-3">
+                <div class="block text-blueGray-600 text-xs font-bold mb-2">
+                  <%= Spot.human_attribute_name('longitude') %>
+                </div>
+                <p><%= @spot.longitude %></p>
+              </div>
+            </div>
           </div>
           <hr class="mt-6 border-b-1 border-blueGray-300" />
           <h6

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -26,7 +26,7 @@
   </td>
   <td>
     <div class="flex">
-      <button class="admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800 mr-2"><%= t('defaults.show') %></button>
+      <%= link_to t('defaults.show'), admin_user_path(user), class: 'admin-btn text-white bg-pink-600 hover:bg-pink-800 font-bold mr-2' %>
       <%= link_to t('defaults.edit'), edit_admin_user_path(user), class: 'admin-btn text-white bg-pink-600 hover:bg-pink-800 font-bold mr-2' %>
       <%= link_to t('defaults.destroy'), admin_user_path(user), method: :delete, data: { confirm: t('defaults.message.delete_confirm') }, class: 'admin-btn admin-delete-btn font-bold mr-2' %>
     </div>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -22,7 +22,7 @@
   <td
     class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
   >
-    <%= user.created_at %>
+    <%= l user.created_at, format: :long %>
   </td>
   <td>
     <div class="flex">

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -26,9 +26,9 @@
   </td>
   <td>
     <div class="flex">
-      <button class="admin-btn admin-nomal-btn font-bold mr-2"><%= t('defaults.show') %></button>
-      <%= link_to t('defaults.edit'), edit_admin_user_path(user), class: 'admin-btn admin-nomal-btn font-bold mr-2' %>
-      <button class="admin-btn admin-delete-btn font-bold mr-2"><%= t('defaults.destroy') %></button>
+      <button class="admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800 mr-2"><%= t('defaults.show') %></button>
+      <%= link_to t('defaults.edit'), edit_admin_user_path(user), class: 'admin-btn text-white bg-pink-600 hover:bg-pink-800 font-bold mr-2' %>
+      <%= link_to t('defaults.destroy'), admin_user_path(user), method: :delete, data: { confirm: t('defaults.message.delete_confirm') }, class: 'admin-btn admin-delete-btn font-bold mr-2' %>
     </div>
   </td>
 </tr>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -17,7 +17,7 @@
   <td
     class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
   >
-    <%= user.role %>
+    <%= user.role_i18n %>
   </td>
   <td
     class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
@@ -27,7 +27,7 @@
   <td>
     <div class="flex">
       <button class="admin-btn admin-nomal-btn mr-2"><%= t('defaults.show') %></button>
-      <button class="admin-btn admin-nomal-btn mr-2"><%= t('defaults.edit') %></button>
+      <%= link_to t('defaults.edit'), edit_admin_user_path(user), class: 'admin-btn admin-nomal-btn mr-2' %>
       <button class="admin-btn admin-delete-btn mr-2"><%= t('defaults.destroy') %></button>
     </div>
   </td>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -1,0 +1,32 @@
+<tr>
+  <td
+    class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+  >
+    <%= user.id %>
+  </td>
+  <td
+    class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+  >
+    <%= user.name %>
+  </td>
+  <td
+    class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+  >
+    <%= user.email %>
+  </td>
+  <td
+    class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+  >
+    <%= user.role %>
+  </td>
+  <td
+    class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+  >
+    <%= user.created_at %>
+  </td>
+  <td>
+    <button class="admin-btn admin-nomal-btn"><%= t('defaults.show') %></button>
+    <button class="admin-btn admin-nomal-btn"><%= t('defaults.edit') %></button>
+    <button class="admin-btn admin-delete-btn"><%= t('defaults.destroy') %></button>
+  </td>
+</tr>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -26,9 +26,9 @@
   </td>
   <td>
     <div class="flex">
-      <button class="admin-btn admin-nomal-btn mr-2"><%= t('defaults.show') %></button>
-      <%= link_to t('defaults.edit'), edit_admin_user_path(user), class: 'admin-btn admin-nomal-btn mr-2' %>
-      <button class="admin-btn admin-delete-btn mr-2"><%= t('defaults.destroy') %></button>
+      <button class="admin-btn admin-nomal-btn font-bold mr-2"><%= t('defaults.show') %></button>
+      <%= link_to t('defaults.edit'), edit_admin_user_path(user), class: 'admin-btn admin-nomal-btn font-bold mr-2' %>
+      <button class="admin-btn admin-delete-btn font-bold mr-2"><%= t('defaults.destroy') %></button>
     </div>
   </td>
 </tr>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -25,8 +25,10 @@
     <%= user.created_at %>
   </td>
   <td>
-    <button class="admin-btn admin-nomal-btn"><%= t('defaults.show') %></button>
-    <button class="admin-btn admin-nomal-btn"><%= t('defaults.edit') %></button>
-    <button class="admin-btn admin-delete-btn"><%= t('defaults.destroy') %></button>
+    <div class="flex">
+      <button class="admin-btn admin-nomal-btn mr-2"><%= t('defaults.show') %></button>
+      <button class="admin-btn admin-nomal-btn mr-2"><%= t('defaults.edit') %></button>
+      <button class="admin-btn admin-delete-btn mr-2"><%= t('defaults.destroy') %></button>
+    </div>
   </td>
 </tr>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -35,6 +35,7 @@
               </div>
             </div>
             <div class="text-right pt-5 pr-4">
+              <%= link_to t('defaults.back'), admin_users_path, class: 'admin-btn bg-white hover:bg-gray-600 hover:text-white font-bold mr-2' %>
               <%= f.submit t('defaults.edit'), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
             </div>
           <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,47 @@
+<div class="px-4 md:px-10 mx-auto w-full">
+  <div class="flex flex-wrap">
+    <div class="w-full lg:w-8/12 px-4">
+      <div
+        class="relative flex flex-col min-w-0 break-words w-full mb-6 shadow-lg rounded-lg bg-blueGray-100 border-0"
+      >
+        <div class="rounded-t bg-white mb-0 px-6 py-6">
+          <div class="text-center flex justify-between">
+            <h6 class="text-blueGray-700 text-xl font-bold">
+              <%= t('.title') %>
+            </h6>
+            <button
+              class="bg-pink-500 text-white active:bg-pink-600 font-bold uppercase text-xs px-4 py-2 rounded shadow hover:shadow-md outline-none focus:outline-none mr-1 ease-linear transition-all duration-150"
+              type="button"
+            >
+              <%= t('defaults.edit') %>
+            </button>
+          </div>
+        </div>
+        <div class="flex-auto px-4 lg:px-10 py-10 pt-0">
+          <%= form_with model: @user, url: edit_admin_user_path(@user), local: true do |f| %>
+            <div class="flex flex-wrap pt-5">
+              <div class="w-full px-4">
+                <div class="relative w-full mb-3">
+                  <%= f.label :name, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <%= f.text_field :name, class: 'border-0 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full ease-linear transition-all duration-150' %>
+                </div>
+              </div>
+              <div class="w-full px-4 pt-3">
+                <div class="relative w-full mb-3">
+                  <%= f.label :email, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <%= f.email_field :email, class: 'border-0 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full ease-linear transition-all duration-150' %>
+                </div>
+              </div>
+              <div class="w-full px-4 pt-3">
+                <div class="relative w-full mb-3">
+                  <%= f.label :role, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <%= f.select :role, User.roles_i18n.invert, {}, class: 'border-0 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full ease-linear transition-all duration-150' %>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -9,16 +9,11 @@
             <h6 class="text-blueGray-700 text-xl font-bold">
               <%= t('.title') %>
             </h6>
-            <button
-              class="bg-pink-500 text-white active:bg-pink-600 font-bold uppercase text-xs px-4 py-2 rounded shadow hover:shadow-md outline-none focus:outline-none mr-1 ease-linear transition-all duration-150"
-              type="button"
-            >
-              <%= t('defaults.edit') %>
-            </button>
           </div>
         </div>
         <div class="flex-auto px-4 lg:px-10 py-10 pt-0">
-          <%= form_with model: @user, url: edit_admin_user_path(@user), local: true do |f| %>
+          <%= form_with model: @user, url: admin_user_path(@user), local: true do |f| %>
+            <%= render 'shared/error_messages', object: f.object %>
             <div class="flex flex-wrap pt-5">
               <div class="w-full px-4">
                 <div class="relative w-full mb-3">
@@ -38,6 +33,9 @@
                   <%= f.select :role, User.roles_i18n.invert, {}, class: 'border-0 px-3 py-3 placeholder-blueGray-300 text-blueGray-600 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full ease-linear transition-all duration-150' %>
                 </div>
               </div>
+            </div>
+            <div class="text-right pt-5 pr-4">
+              <%= f.submit t('defaults.edit'), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
             </div>
           <% end %>
         </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#index</h1>
+<p>Find me in app/views/admin/users/index.html.erb</p>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,2 +1,99 @@
-<h1>Admin::Users#index</h1>
-<p>Find me in app/views/admin/users/index.html.erb</p>
+<div class="px-4 md:px-10 mx-auto w-full -m-24">
+  <div class="flex flex-wrap mt-4">
+    <div class="w-full mb-12 px-4">
+      <div
+        class="relative flex flex-col min-w-0 break-words w-full mt-20 mb-20 shadow-lg rounded bg-white"
+      >
+        <div class="rounded-t mb-0 px-4 py-3 border-0">
+          <div class="flex flex-wrap items-center">
+            <div
+              class="relative w-full px-4 max-w-full flex-grow flex-1"
+            >
+              <h3 class="font-semibold text-lg text-blueGray-700">
+                <%= t('.title') %>
+              </h3>
+            </div>
+          </div>
+        </div>
+        <div class="block w-full overflow-x-auto">
+          <!-- Projects table -->
+          <table
+            class="items-center w-full bg-transparent border-collapse"
+          >
+            <thead>
+              <tr>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                >
+                 ID
+                </th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                >
+                  <%= User.human_attribute_name('name') %>
+                </th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                >
+                  <%= User.human_attribute_name('email') %>
+                </th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                >
+                  <%= User.human_attribute_name('role') %>
+                </th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                >
+                  <%= t('defaults.created_at') %>
+                </th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                ></th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                >
+                </th>
+                <th
+                  class="px-6 align-middle border border-solid py-3 text-xs uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left bg-blueGray-50 text-blueGray-500 border-blueGray-100"
+                ></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td
+                  class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+                >
+                  1
+                </td>
+                <td
+                  class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+                >
+                  pending
+                </td>
+                <td
+                  class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+                >
+                  example.com
+                </td>
+                <td
+                  class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+                >
+                  role
+                </td>
+                <td
+                  class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
+                >
+                  1
+                </td>
+                <td>
+                  <button><%= t('defaults.edit') %></button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -87,7 +87,8 @@
                   1
                 </td>
                 <td>
-                  <button><%= t('defaults.edit') %></button>
+                  <button class="admin-btn admin-nomal-btn"><%= t('defaults.edit') %></button>
+                  <button class="admin-btn admin-delete-btn"><%= t('defaults.destroy') %></button>
                 </td>
               </tr>
             </tbody>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -60,37 +60,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr>
-                <td
-                  class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
-                >
-                  1
-                </td>
-                <td
-                  class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
-                >
-                  pending
-                </td>
-                <td
-                  class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
-                >
-                  example.com
-                </td>
-                <td
-                  class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
-                >
-                  role
-                </td>
-                <td
-                  class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-xs whitespace-nowrap p-4"
-                >
-                  1
-                </td>
-                <td>
-                  <button class="admin-btn admin-nomal-btn"><%= t('defaults.edit') %></button>
-                  <button class="admin-btn admin-delete-btn"><%= t('defaults.destroy') %></button>
-                </td>
-              </tr>
+              <%= render @users %>
             </tbody>
           </table>
         </div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -12,32 +12,35 @@
           </div>
         </div>
         <div class="flex-auto px-4 lg:px-10 py-10 pt-0">
-          <%= form_with model: @user, url: admin_user_path(@user), local: true do |f| %>
-            <%= render 'shared/error_messages', object: f.object %>
-            <div class="flex flex-wrap pt-5">
-              <div class="w-full px-4">
-                <div class="relative w-full mb-3">
-                  <%= f.label :name, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
-                  <p><%= @user.name %></p>
+          <div class="flex flex-wrap pt-5">
+            <div class="w-full px-4">
+              <div class="relative w-full mb-3">
+                <div class="block text-blueGray-600 text-xs font-bold mb-2">
+                  <%= User.human_attribute_name('name') %>
                 </div>
-              </div>
-              <div class="w-full px-4 pt-3">
-                <div class="relative w-full mb-3">
-                  <%= f.label :email, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
-                  <p><%= @user.email %></p>
-                </div>
-              </div>
-              <div class="w-full px-4 pt-3">
-                <div class="relative w-full mb-3">
-                  <%= f.label :role, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
-                  <p><%= @user.role_i18n %></p>
-                </div>
+                <p><%= @user.name %></p>
               </div>
             </div>
-            <div class="text-right pt-5 pr-4">
-              <%= link_to t('defaults.edit'), edit_admin_user_path(@user), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
+            <div class="w-full px-4 pt-3">
+              <div class="relative w-full mb-3">
+                <div class="block text-blueGray-600 text-xs font-bold mb-2">
+                  <%= User.human_attribute_name('email') %>
+                </div>
+                <p><%= @user.email %></p>
+              </div>
             </div>
-          <% end %>
+            <div class="w-full px-4 pt-3">
+              <div class="relative w-full mb-3">
+                <div class="block text-blueGray-600 text-xs font-bold mb-2">
+                  <%= User.human_attribute_name('role') %>
+                </div>
+                <p><%= @user.role_i18n %></p>
+              </div>
+            </div>
+          </div>
+          <div class="text-right pt-5 pr-4">
+            <%= link_to t('defaults.edit'), edit_admin_user_path(@user), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -40,6 +40,7 @@
           </div>
           <div class="text-right pt-5 pr-4">
             <%= link_to t('defaults.edit'), edit_admin_user_path(@user), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
+            <%= link_to t('defaults.destroy'), admin_user_path(@user), method: :delete, data: { confirm: t('defaults.message.delete_confirm') }, class: 'admin-btn admin-delete-btn font-bold mr-2' %>
           </div>
         </div>
       </div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,45 @@
+<div class="px-4 md:px-10 mx-auto w-full">
+  <div class="flex flex-wrap">
+    <div class="w-full lg:w-8/12 px-4">
+      <div
+        class="relative flex flex-col min-w-0 break-words w-full mb-6 shadow-lg rounded-lg bg-blueGray-100 border-0"
+      >
+        <div class="rounded-t bg-white mb-0 px-6 py-6">
+          <div class="text-center flex justify-between">
+            <h6 class="text-blueGray-700 text-xl font-bold">
+              <%= t('.title') %>
+            </h6>
+          </div>
+        </div>
+        <div class="flex-auto px-4 lg:px-10 py-10 pt-0">
+          <%= form_with model: @user, url: admin_user_path(@user), local: true do |f| %>
+            <%= render 'shared/error_messages', object: f.object %>
+            <div class="flex flex-wrap pt-5">
+              <div class="w-full px-4">
+                <div class="relative w-full mb-3">
+                  <%= f.label :name, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <p><%= @user.name %></p>
+                </div>
+              </div>
+              <div class="w-full px-4 pt-3">
+                <div class="relative w-full mb-3">
+                  <%= f.label :email, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <p><%= @user.email %></p>
+                </div>
+              </div>
+              <div class="w-full px-4 pt-3">
+                <div class="relative w-full mb-3">
+                  <%= f.label :role, class: 'block text-blueGray-600 text-xs font-bold mb-2' %>
+                  <p><%= @user.role_i18n %></p>
+                </div>
+              </div>
+            </div>
+            <div class="text-right pt-5 pr-4">
+              <%= link_to t('defaults.edit'), edit_admin_user_path(@user), class: 'admin-btn text-white font-bold bg-pink-600 hover:bg-pink-800' %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,9 @@ module MitsuboshiPowderRooms
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
 
+    config.time_zone = 'Tokyo'	
+    config.active_record.default_timezone = :local
+    
     config.generators do |g|
       g.assets false
       g.helper false

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -30,4 +30,8 @@ ja:
         feedback_comment: '評価コメント'
         tag_ids: 'ここを評価したい！'
         
-
+  enums:
+    user:
+      role:
+        general: 一般
+        admin: 管理者

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,6 +15,8 @@ ja:
       spot:
         name: 'スポット名'
         address: '住所'
+        latitude: '緯度'
+        longitude: '経度'
         user_id: 'ユーザー名'
       feedback:
         rate: '総合点'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -11,6 +11,7 @@ ja:
         password: 'パスワード'
         password_confirmation: 'パスワード確認'
         avator: 'アバター'
+        role: '権限'
       spot:
         name: 'スポット名'
         address: '住所'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,6 +15,7 @@ ja:
       spot:
         name: 'スポット名'
         address: '住所'
+        user_id: 'ユーザー名'
       feedback:
         rate: '総合点'
         feedback_comment: '評価コメント'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -94,6 +94,7 @@ ja:
         title: 'スポット詳細'
         about_spot: '基本情報'
         equipment_details: '設備詳細'
+        none: 'なし'
       edit:
         title: 'スポット編集'
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,7 @@ ja:
     mypage: 'マイページ'
     search: '検索'
     post: '投稿'
+    show: '詳細'
     edit: '編集'
     destroy: '削除'
     save: '保存'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -22,6 +22,7 @@ ja:
     created_at: '作成日時'
     about_spot: '基本情報'
     equipment_details: '設備詳細'
+    back: '戻る'
     message:
       require_login: 'ログインしてください'
       created: "%{item}を作成しました"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,6 +20,8 @@ ja:
     give_feedback: '評価する'
     multiple_choices_allowed: '※複数選択可'
     created_at: '作成日時'
+    about_spot: '基本情報'
+    equipment_details: '設備詳細'
     message:
       require_login: 'ログインしてください'
       created: "%{item}を作成しました"
@@ -92,8 +94,6 @@ ja:
         latitude_and_longitude: '緯度・経度'
       show:
         title: 'スポット詳細'
-        about_spot: '基本情報'
-        equipment_details: '設備詳細'
         none: 'なし'
       edit:
         title: 'スポット編集'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -27,6 +27,7 @@ ja:
       updated: "%{item}を編集しました"
       not_updated: "%{item}を編集できませんでした"
       deleted: "%{item}を削除しました"
+      delete_confirm: "本当に削除しますか？"
       not_authorized: '権限がありません'
   users:
     new:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -81,4 +81,9 @@ ja:
     users:
       index:
         title: 'ユーザー一覧'
+      show:
+        title: 'ユーザー詳細'
+      edit:
+        title: 'ユーザー編集'
+        about_user: 'ユーザー情報'
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -86,5 +86,12 @@ ja:
         title: 'ユーザー詳細'
       edit:
         title: 'ユーザー編集'
-        about_user: 'ユーザー情報'
+    spots:
+      index:
+        title: 'スポット一覧'
+        latitude_and_longitude: '緯度・経度'
+      show:
+        title: 'スポット詳細'
+      edit:
+        title: 'スポット編集'
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -18,6 +18,7 @@ ja:
     reviews: '件の評価'
     give_feedback: '評価する'
     multiple_choices_allowed: '※複数選択可'
+    created_at: '作成日時'
     message:
       require_login: 'ログインしてください'
       created: "%{item}を作成しました"
@@ -76,3 +77,7 @@ ja:
     dashboards:
       index:
         title: 'ダッシュボード'
+    users:
+      index:
+        title: 'ユーザー一覧'
+

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -92,6 +92,8 @@ ja:
         latitude_and_longitude: '緯度・経度'
       show:
         title: 'スポット詳細'
+        about_spot: '基本情報'
+        equipment_details: '設備詳細'
       edit:
         title: 'スポット編集'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,6 @@ Rails.application.routes.draw do
     get 'login', to: 'user_sessions#new'
     post 'login', to: 'user_sessions#create'
     delete 'logout', to: 'user_sessions#destroy'
+    resources :users, only: %i[index edit update show destroy]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,5 +20,6 @@ Rails.application.routes.draw do
     post 'login', to: 'user_sessions#create'
     delete 'logout', to: 'user_sessions#destroy'
     resources :users, only: %i[index edit update show destroy]
+    resources :spots, only: %i[index edit update show destroy]
   end
 end


### PR DESCRIPTION
## 概要
管理画面にユーザー、スポット情報の一覧を作成、管理画面から編集・削除が行えるようにしました。

<img src="https://i.gyazo.com/f942b60ac4b817534b4cb0903aaf9968.gif" width="70%">

#### ユーザー関連
1bce8b7　`config/route` に `admin/user` を追加
15ed28c　`bundle exec rails g controller Admin::Users index` を実行
f780745　`admin/users_controller` に index、show、destroy を追加
25eee93　ユーザー一覧を追加
45662b9　`enum_help` を導入、enum の翻訳を追加
56eca1f9　編集画面から `user#edit`、`update` が機能することを確認
be660e9　ユーザーの削除機能を追加
e184a3a8　ユーザー詳細画面を追加

#### スポット情報関連
ef057b61　`config/routes` に `spot` を追加
2a6a275　`rails g controller Admin::spots index` を実行
457a39f　管理画面にスポット情報一覧を作成
92b5de6　`admin_helper` を作成、各スポットに緯度経度があるかを表示させる
00a16012　スポット情報詳細に設備詳細を表示
4c28148c　スポット情報の編集機能を追加
7611ca03　スポット編集から緯度・経度の編集ができるようにする
aa1ac4ee　`user`、`spot` に編集、戻るボタンを追加

## 確認方法
① `bundle exec foreman` でサーバーを起動し、`localhost:3000/admin`にアクセス。
②ユーザー、スポットそれぞれに以下の機能が実装されていることを確認してください。
#### ユーザー関連
- サイドバーのリンクから、`admin/users` にアクセスできること 
- `admin/users` に登録ユーザーの一覧が表示されること
- 詳細ボタンから、各ユーザー情報の詳細にアクセスできること
- 編集ボタンから、各ユーザー情報の編集ができること
- 削除ボタンから、各ユーザー情報の削除ができること

#### スポット情報関連
- サイドバーのリンクから、`admin/spots` にアクセスできること 
- `admin/spots` にスポット情報の一覧が表示されること
- 詳細ボタンから、各スポット情報の詳細にアクセスできること
- 編集ボタンから、各スポット情報の編集ができること
- 削除ボタンから、各スポット情報の削除ができること 

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした
