### PR TITLE
Twitter ログインのエラーを解消①

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -117,7 +117,7 @@ Rails.application.config.sorcery.configure do |config|
   #
   config.twitter.key = ENV['TWITTER_KEY_ID']
   config.twitter.secret = ENV['TWITTER_SECRET_KEY_ID']
-  config.twitter.callback_url = "https://www.mitsuboshi-powder-rooms.jp/oauth/callback?provider=twitter"
+  config.twitter.callback_url = "https://www.mitsuboshi-powder-rooms.jp/oauth/callback"
   config.twitter.user_info_mapping = {
     email: 'screen_name',
     name: 'name'


### PR DESCRIPTION
## 概要
Heroku にデプロイ後、本番系の「Twitterアカウントで登録・ログイン」を押すと、以下のエラーが発生する。

<img src="https://user-images.githubusercontent.com/93573830/196434129-9108a44c-8b0a-4a9e-a732-9213e17de542.png" width="50%">

5e0b81c　Twitter の callback_URL を変更

## 確認方法

・本番系から「Twitterアカウントで登録・ログイン」へアクセス
　→ 上記のエラーが表示されず、アカウントでのログインが正常に行われることを確認。