### PR TITLE
続・Twitter ログインのエラーを解消②

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full max-w-sm my-24">
   <h1 class="font-bold mb-10"><%= t('.title') %></h1>
   <%= link_to auth_at_provider_path(provider: :twitter) do %>
-    <button class="w-full text-white bg-twitter-blue hover:bg-mitsuboshi-blue text-center rounded shadow mb-5 py-2 px-4">
+    <button class="w-full text-white font-bold bg-twitter-blue hover:bg-mitsuboshi-blue text-center rounded shadow mb-5 py-2 px-4">
       <p><i class="fab fa-twitter"></i> <%= t('.login_with_twitter') %></p>
     </button>
   <% end %>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -117,7 +117,7 @@ Rails.application.config.sorcery.configure do |config|
   #
   config.twitter.key = ENV['TWITTER_KEY_ID']
   config.twitter.secret = ENV['TWITTER_SECRET_KEY_ID']
-  config.twitter.callback_url = "https://www.mitsuboshi-powder-rooms.jp/oauth/callback"
+  config.twitter.callback_url = "https://www.mitsuboshi-powder-rooms.jp/oauth/callback?provider=twitter"
   config.twitter.user_info_mapping = {
     email: 'screen_name',
     name: 'name'


### PR DESCRIPTION
## 概要

続・Twitter ログインのエラーを解消②

<img src="https://user-images.githubusercontent.com/93573830/196447866-5a50dd01-4301-42b6-bf57-cb0618605687.png" width="50%">

- Twitter Developer の Callback を `https://XXXX/oauth/callback` に変更
→ ログインまではできるようになったけど、その後の Callback で上記のエラーが出る。

- いったん前回変更した Rails 側の Callback_URL をもとに戻す

f7f00b4d　`callback_URL` をもとに戻す

## 確認方法
- 本番系から「Twitterアカウントで登録・ログイン」へアクセス
→ 上記のエラーが表示されず、アカウントでのログインが正常に行われることを確認。