### PR TITLE
Google Map の「現在地へ移動」ボタンを修正ほか

### DIFF
--- a/app/javascript/js/google_map.js
+++ b/app/javascript/js/google_map.js
@@ -44,8 +44,6 @@ window.initMap = () => {
 
         setCurrentLocation(currentLocation)
 
-        alert('現在地を取得しました！');
-
         createMarker()
       })
     } else {

--- a/app/javascript/js/google_map.js
+++ b/app/javascript/js/google_map.js
@@ -26,11 +26,10 @@ window.initMap = () => {
   const locationButton = document.createElement('button');
 
   locationButton.textContent = '現在地へ移動する'
-  locationButton.classList.add('block', 'text-center', 'rounded', 'shadow', 'mx-2', 'py-2', 'px-4', 'text-white', 'font-bold', 'text-base', 'bg-mitsuboshi-blue', 'hover:bg-baby-blue')
+  locationButton.classList.add('custom-map-control-button')
   map.controls[google.maps.ControlPosition.LEFT_TOP].push(locationButton);
 
   locationButton.addEventListener('click', () => {
-
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition((position) => {
         let currentLocation = new window.google.maps.LatLng(
@@ -44,6 +43,8 @@ window.initMap = () => {
         })
 
         setCurrentLocation(currentLocation)
+
+        alert('現在地を取得しました！');
 
         createMarker()
       })

--- a/app/javascript/stylesheets/main.css
+++ b/app/javascript/stylesheets/main.css
@@ -47,3 +47,25 @@ body {
   height: 250px;
   width: 100%;
 }
+
+.custom-map-control-button {
+  display: block;
+  text-align: center;
+  color: rgb(255 255 255);
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  background-color: rgb(117 204 232);
+}
+
+.custom-map-control-button:hover {
+  background-color: rgb(165 222 229);
+}

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,7 +2,7 @@
   <div class="max-w-md pb-24">
   <%= image_pack_tag 'media/images/top.png' %>
     <div class="text-center border-dotted border-t-2 border-fitting-pink py-20">
-      <h1 class="font-kaisei text-3xl title-font text-gray-900 mb-4">三つ星トイレの使い方</h1>
+      <h1 class="font-kaisei text-2xl title-font text-gray-900 mb-4">三つ星トイレの使い方</h1>
       <div class="text-base leading-relaxed mx-auto text-gray-500">
         <p>　三つ星トイレは、キレイで設備も豊富で、まるで三つ星ホテルのようなトイレを投稿・共有するトイレ検索サービスです。</p>
       </div>
@@ -16,7 +16,7 @@
           <%= image_pack_tag 'media/images/search.svg' %>
         </div>
         <div class="flex-grow">
-          <h2 class="font-kaisei text-gray-900 text-lg title-font font-medium mb-3">その1. スポットを検索してみよう</h2>
+          <h2 class="font-kaisei text-gray-900 text-lg title-font font-bold mb-3">その1. スポットを検索してみよう</h2>
           <p class="leading-relaxed text-base text-gray-500">　まずは、ページ下部の「検索」ボタンから、スポットを検索・閲覧してみましょう。 スポットの検索方法は、「現在地から検索」と「住所・スポット名から検索」の二種類。リスト表示にすると、現在投稿されているすべてのスポットの情報を閲覧することができます。</p>
         </div>
       </div>
@@ -25,7 +25,7 @@
           <%= image_pack_tag 'media/images/login.svg' %>
         </div>
         <div class="flex-grow">
-          <h2 class="font-kaisei text-gray-900 text-lg title-font font-medium mb-3">その2. ユーザー登録をしてみよう</h2>
+          <h2 class="font-kaisei text-gray-900 text-lg title-font font-bold mb-3">その2. ユーザー登録をしてみよう</h2>
           <p class="leading-relaxed text-base text-gray-500">　三つ星トイレにユーザー登録すると、「スポット情報の投稿」や「投稿されたスポットへの三つ星評価」、「お気に入りのスポットの登録」などができるようになります。</p>
         </div>
       </div>
@@ -34,7 +34,7 @@
           <%= image_pack_tag 'media/images/post.svg' %>
         </div>
         <div class="flex-grow">
-          <h2 class="font-kaisei text-gray-900 text-lg title-font font-medium mb-3">その3. お気に入りのスポットを投稿・評価しよう</h2>
+          <h2 class="font-kaisei text-gray-900 text-lg title-font font-bold mb-3">その3. お気に入りのスポットを投稿・評価しよう</h2>
           <p class="leading-relaxed text-base text-gray-500">　ユーザー登録を済ませたら、ページ下部の「投稿」ボタンから、あなたが見つけたお気に入りのスポットを投稿してみましょう。投稿後、スポット情報の詳細から、三段階の三つ星評価をすることができます。</p>
         </div>
       </div>


### PR DESCRIPTION
## 概要
Heroku デプロイ後、Google Map の「現在地へ移動」ボタンのスタイルが消えたため、修正を行いました。
また、サービス説明文のレイアウトも修正しました。

d4c6e80e　Map のボタンのスタイルを CSS に変更、挙動を確認
48955770　サービス紹介文のレイアウトを修正

## 確認方法
① Heroku デプロイ後、Google Map 上部に「現在地へ移動」ボタンが表示されていることを確認してください。
② また、「現在地へ移動」ボタンを押して、現在地が取得できることも確認してください。

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした

## コメント
スマートフォンだと「現在地へ移動」ボタンが機能しなかったので、Heroku へデプロイ後、要確認。