### PR TITLE
Google Map の「現在地へ移動」ボタンを修正②

### DIFF
--- a/app/javascript/js/google_map.js
+++ b/app/javascript/js/google_map.js
@@ -29,7 +29,9 @@ window.initMap = () => {
   locationButton.classList.add('custom-map-control-button')
   map.controls[google.maps.ControlPosition.LEFT_TOP].push(locationButton);
 
-  locationButton.addEventListener('click', () => {
+  let clickEventType = (( window.ontouchstart!==null) ? 'click' : 'touchend');
+
+  locationButton.addEventListener(clickEventType, () => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition((position) => {
         let currentLocation = new window.google.maps.LatLng(


### PR DESCRIPTION
## 概要

Heroku へデプロイ後、スマホで実行した場合だけ「現在地へ移動」ボタンが機能しない問題が継続中。
`addEventListner` の判定に修正を加えました。

d643ed45　map の「現在地へ移動」ボタンの判定を `clickEventType` に変更

## 確認方法
① Heroku へデプロイ後、スマートフォンからサービスにアクセス。
② 「現在地へ移動」ボタンが正常に機能することを確認してください。

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした