### PR TITLE
Google Map の「現在地へ移動」ボタンを修正③ 

### DIFF
--- a/app/javascript/js/google_map.js
+++ b/app/javascript/js/google_map.js
@@ -29,9 +29,7 @@ window.initMap = () => {
   locationButton.classList.add('custom-map-control-button')
   map.controls[google.maps.ControlPosition.LEFT_TOP].push(locationButton);
 
-  let clickEventType = (( window.ontouchstart!==null) ? 'click' : 'touchend');
-
-  locationButton.addEventListener(clickEventType, () => {
+  locationButton.addEventListener('click', () => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition((position) => {
         let currentLocation = new window.google.maps.LatLng(

--- a/app/javascript/stylesheets/main.css
+++ b/app/javascript/stylesheets/main.css
@@ -64,8 +64,5 @@ body {
   font-size: 1rem;
   line-height: 1.5rem;
   background-color: rgb(117 204 232);
-}
-
-.custom-map-control-button:hover {
-  background-color: rgb(165 222 229);
+  cursor: pointer;
 }


### PR DESCRIPTION
## 概要
Heroku へデプロイ後、スマホで実行した場合だけ「現在地へ移動」ボタンが機能しない問題が継続中。
前回追加した `addEventListner` の判定修正を削除し、`main.css` に ` cursor: pointer` を追加してみる。

2fc74f09　map の `clickEventType` を削除、`cursor: pointer` を追加

## 確認方法
① Heroku へデプロイ後、スマートフォンからサービスにアクセス。
② 「現在地へ移動」ボタンが正常に機能することを確認してください。

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした
