### PR TITLE
google_map.js のコードを修正 

### DIFF
--- a/app/javascript/js/google_map.js
+++ b/app/javascript/js/google_map.js
@@ -3,6 +3,7 @@ let map
 let spotLatLng
 let markerCurrentLocation
 let geocoder
+let currentInfoWindow
 
 const marker = []
 const infoWindow = []
@@ -100,7 +101,11 @@ function createMarker() {
     })
 
     marker[i].addListener('click', function () {
+      if (currentInfoWindow) {
+        currentInfoWindow.close();
+      }
       infoWindow[i].open(map, marker[i])
-    })
+      currentInfoWindow = infoWindow[i]
+    });
   }
 }

--- a/app/javascript/js/google_map.js
+++ b/app/javascript/js/google_map.js
@@ -29,9 +29,7 @@ window.initMap = () => {
   locationButton.classList.add('custom-map-control-button')
   map.controls[google.maps.ControlPosition.LEFT_TOP].push(locationButton);
 
-  let clickEventType = window.ontouchstart === null ? 'touchstart': 'click';
-
-  locationButton.addEventListener(clickEventType, () => {
+  locationButton.addEventListener('click', () => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition((position) => {
         let currentLocation = new window.google.maps.LatLng(


### PR DESCRIPTION
## 概要
`google_map.js` のコードを修正しました。

46f5c39b　スクロールの動作に影響があったため、`addEventListener` のイベント判定を削除
94659fbb　スポット情報のWindowが複数開かないようにコードを追加

## 確認方法
① Heroku へデプロイ後、スマートフォンからサービスにアクセスし、以下の動作を確認してください。
#### スクロールなど、Google Map まわりの動作に以上がないこと

#### スポット情報のWindowが複数開かないこと
<img src="https://i.gyazo.com/1e34199e3308f9899977cf1bafbc6008.gif" width="50%>

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした

## コメント
Google Map の「現在地へ移動」ボタンについては、引き続き調査中…。