### PR TITLE
データベースのパフォーマンス対策のため、各テーブルに index を追加

### DIFF
--- a/db/migrate/20230122081222_add_index_to_spot_created_at.rb
+++ b/db/migrate/20230122081222_add_index_to_spot_created_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToSpotCreatedAt < ActiveRecord::Migration[6.1]
+  def change
+    add_index :spots, :created_at
+  end
+end

--- a/db/migrate/20230122082313_add_index_to_feedback_created_at.rb
+++ b/db/migrate/20230122082313_add_index_to_feedback_created_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToFeedbackCreatedAt < ActiveRecord::Migration[6.1]
+  def change
+    add_index :feedbacks, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_20_014854) do
+ActiveRecord::Schema.define(version: 2023_01_22_081222) do
 
   create_table "authentications", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 2022_10_20_014854) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["address"], name: "index_spots_on_address", unique: true
+    t.index ["created_at"], name: "index_spots_on_created_at"
     t.index ["name"], name: "index_spots_on_name", unique: true
     t.index ["user_id"], name: "index_spots_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_22_081222) do
+ActiveRecord::Schema.define(version: 2023_01_22_082313) do
 
   create_table "authentications", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2023_01_22_081222) do
     t.integer "spot_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["created_at"], name: "index_feedbacks_on_created_at"
     t.index ["spot_id"], name: "index_feedbacks_on_spot_id"
     t.index ["user_id"], name: "index_feedbacks_on_user_id"
   end


### PR DESCRIPTION
## 概要
スポット情報を増やすにあたって、データベースのパフォーマンス対策のため、各テーブルに `index` を追加しました。
#### Spot テーブル関連
c576fe09　Spot テーブルに `created_at` の `index` を追加
#### Feedback テーブル関連
416585e1　Feedback テーブルに `created_at` の `index` を追加

## 確認方法
Heroku のコンソールにて `EXPLAIN` を行い、パフォーマンスの改善が見られるか、確認してください。

#### 【Spot テーブルの場合】
`Spot.order(created_at: :desc).explain`
#### 【Feedback テーブルの場合】
`Feedback.order(created_at: :desc).explain`
## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした
