### PR TITLE
「評価から並び替え」ボタンのエラーを修正

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -9,7 +9,16 @@ class SpotsController < ApplicationController
     @search_spots_form = SearchSpotsForm.new(search_params)
 
     @spots = if params[:rate]
-               @search_spots_form.search.by_rating
+               @search_spots_form.search
+                 .includes(:feedbacks).group(:id)
+                 .sort_by do |spot|
+                   feedbacks = spot.feedbacks
+                   if feedbacks.present?
+                    feedbacks.map(&:rate).sum / feedbacks.size
+                    else
+                     0
+                    end
+                 end.reverse
              else
                @search_spots_form.search.latest
              end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -9,16 +9,7 @@ class SpotsController < ApplicationController
     @search_spots_form = SearchSpotsForm.new(search_params)
 
     @spots = if params[:rate]
-               @search_spots_form.search
-                 .includes(:feedbacks).group(:id)
-                 .sort_by do |spot|
-                   feedbacks = spot.feedbacks
-                   if feedbacks.present?
-                    feedbacks.map(&:rate).sum / feedbacks.size
-                    else
-                     0
-                    end
-                 end.reverse
+               @search_spots_form.search.sort_by_total_rating
              else
                @search_spots_form.search.latest
              end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -13,17 +13,17 @@ class Spot < ApplicationRecord
   after_validation :geocode, if: :address_changed?
 
   scope :latest, -> { order(created_at: :desc) }
-  scope :sort_by_total_rating, -> {
+  scope :sort_by_total_rating, lambda {
     includes(:feedbacks).group(:id)
-     .sort_by do |spot|
-       feedbacks = spot.feedbacks
-       if feedbacks.present?
+                        .sort_by do |spot|
+      feedbacks = spot.feedbacks
+      if feedbacks.present?
         feedbacks.map(&:rate).sum / feedbacks.size
-        else
-         0
-        end
-     end
-     .reverse
+      else
+        0
+      end
+    end
+                        .reverse
   }
   scope :by_equipments, lambda { |equipment_detail_ids|
     left_joins(:equipment_details)

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -13,6 +13,18 @@ class Spot < ApplicationRecord
   after_validation :geocode, if: :address_changed?
 
   scope :latest, -> { order(created_at: :desc) }
+  scope :sort_by_total_rating, -> {
+    includes(:feedbacks).group(:id)
+     .sort_by do |spot|
+       feedbacks = spot.feedbacks
+       if feedbacks.present?
+        feedbacks.map(&:rate).sum / feedbacks.size
+        else
+         0
+        end
+     end
+     .reverse
+  }
   scope :by_equipments, lambda { |equipment_detail_ids|
     left_joins(:equipment_details)
       .where(equipment_details: { id: equipment_detail_ids })

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -16,13 +16,9 @@ class Spot < ApplicationRecord
   scope :sort_by_total_rating, lambda {
     includes(:feedbacks).group(:id)
                         .sort_by do |spot|
-      feedbacks = spot.feedbacks
-      if feedbacks.present?
-        feedbacks.map(&:rate).sum / feedbacks.size
-      else
-        0
-      end
-    end
+                          feedbacks = spot.feedbacks
+                          feedbacks.present? ? feedbacks.sum('feedbacks.rate') / feedbacks.size : 0
+                        end
                         .reverse
   }
   scope :by_equipments, lambda { |equipment_detail_ids|

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -13,9 +13,6 @@ class Spot < ApplicationRecord
   after_validation :geocode, if: :address_changed?
 
   scope :latest, -> { order(created_at: :desc) }
-  scope :by_rating, lambda {
-    left_joins(:feedbacks).group(:id).order('MAX(feedbacks.rate) DESC')
-  }
   scope :by_equipments, lambda { |equipment_detail_ids|
     left_joins(:equipment_details)
       .where(equipment_details: { id: equipment_detail_ids })


### PR DESCRIPTION
## 概要
Heroku へのデプロイ後、「評価から並び替え」ボタンを押すと以下のようなエラーが発生。

<img src="https://i.gyazo.com/dd5f624f1869ae2b43321fb8fc2ee365.gif" width="50%">

### 【エラーが発生した原因】
- `by_rating` のコードがひとつのスポットに対し、複数の評価があった場合に対応していなかった。
```
  scope :by_rating, lambda {
    left_joins(:feedbacks).group(:id).order('MAX(feedbacks.rate) DESC')
  }
```
#### Spot モデルのスコープを修正
653e02af　`by_rating` のスコープを一旦削除
115c8918　`spots_controller` 内にコードを記述、評価の平均値からの並び替えができるようにする
f0dea6bb　`spots_controller` のコードを削除、`scope` に変更

## 確認方法
サーバーを起動し、 `localhost:3000/spots` のリストに遷移、「評価から並び替え」ボタンの挙動を確認してください。
#### ①  `feedbacks.rate` の平均値から並び替えができること
<img src="https://i.gyazo.com/c7525f138f7fd5a9ffbd16ff7c726eae.gif" width="50%">

#### ② ひとつのスポットに対し、評価を複数追加しても、①の挙動が変わらないこと

## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした

## コメント
Heroku にデプロイ後、エラーが発生しないことを確認。