### PR TITLE
スポットの名前と住所が不正（空欄、すでにある）のとき、ワーニングを表示させる

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -25,7 +25,6 @@ class SpotsController < ApplicationController
     if @form.save
       redirect_to spots_path, success: t('defaults.message.created', item: Spot.model_name.human)
     else
-      binding.pry
       flash.now['danger'] = t('defaults.message.not_created', item: Spot.model_name.human)
       render :new
     end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,7 +1,7 @@
 class SpotsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
   before_action :find_spot, only: %i[edit update destroy]
-  before_action :set_equipment_details, only: %i[index new edit]
+  before_action :set_equipment_details, only: %i[index new create edit update]
 
   def index
     gon.spots = Spot.all
@@ -25,6 +25,7 @@ class SpotsController < ApplicationController
     if @form.save
       redirect_to spots_path, success: t('defaults.message.created', item: Spot.model_name.human)
     else
+      binding.pry
       flash.now['danger'] = t('defaults.message.not_created', item: Spot.model_name.human)
       render :new
     end

--- a/app/forms/spot_form.rb
+++ b/app/forms/spot_form.rb
@@ -35,8 +35,8 @@ class SpotForm
         end
       end
     end
-
-    true
+  rescue ActiveRecord::RecordInvalid
+    false
   end
 
   def to_model


### PR DESCRIPTION
## 概要
スポット情報が不正なとき、ワーニングが出ず、エラーになっていたため改修しました。

16b746118　`save` メソッドに バリデーションレスキューを追加
51a2f0d91　`create` 、 `update` に設備詳細の変数を追加
c2592b9b　`spots_controller` の `binding.pry` を削除

## 確認方法
Heroku にデプロイ後、名前と住所が空欄の登録を行い、ワーニングが出ることを確認してください。
## チェックリスト
- [x] `rubocop` をパスした
- [x] `yarn run fix` をパスした
