### PR TITLE
Ruby アップデート後の Heroku デプロイエラーを解消①

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,6 +422,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   better_errors


### PR DESCRIPTION
## 概要
Heroku デプロイ時、以下のようなエラーが出たため、 `Gemfile.lock` を書き換える。
> Your bundle only supports platforms ["arm64-darwin-21"] but your local platform
remote:        is x86_64-linux. Add the current platform to the lockfile with
remote:        `bundle lock --add-platform x86_64-linux` and try again.
>
5653266e3　`Gemfile.lock` に `x_86_64-linux` を追加

## 確認方法
①プルリクの「File Changed」から `Gemfile.lock` を確認
　→ PLATFORMS に「x_86_64-linux」が追加されていることを確認してください。